### PR TITLE
Dex Uniswap V2 Pair events

### DIFF
--- a/parse/table_definitions_avalanche/traderjoe/UniswapV2Pair_event_Approval.json
+++ b/parse/table_definitions_avalanche/traderjoe/UniswapV2Pair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "traderjoe",
+        "table_name": "UniswapV2Pair_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "value",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/traderjoe/UniswapV2Pair_event_Burn.json
+++ b/parse/table_definitions_avalanche/traderjoe/UniswapV2Pair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "traderjoe",
+        "table_name": "UniswapV2Pair_event_Burn",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/traderjoe/UniswapV2Pair_event_Mint.json
+++ b/parse/table_definitions_avalanche/traderjoe/UniswapV2Pair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "traderjoe",
+        "table_name": "UniswapV2Pair_event_Mint",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/traderjoe/UniswapV2Pair_event_Sync.json
+++ b/parse/table_definitions_avalanche/traderjoe/UniswapV2Pair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve0",
+                    "type": "uint112"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve1",
+                    "type": "uint112"
+                }
+            ],
+            "name": "Sync",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "traderjoe",
+        "table_name": "UniswapV2Pair_event_Sync",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "reserve0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reserve1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/pancakeswap/UniswapV2Pair_event_Approval.json
+++ b/parse/table_definitions_bsc/pancakeswap/UniswapV2Pair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "pancakeswap",
+        "table_name": "UniswapV2Pair_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "value",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/pancakeswap/UniswapV2Pair_event_Burn.json
+++ b/parse/table_definitions_bsc/pancakeswap/UniswapV2Pair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "pancakeswap",
+        "table_name": "UniswapV2Pair_event_Burn",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/pancakeswap/UniswapV2Pair_event_Mint.json
+++ b/parse/table_definitions_bsc/pancakeswap/UniswapV2Pair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "pancakeswap",
+        "table_name": "UniswapV2Pair_event_Mint",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/pancakeswap/UniswapV2Pair_event_Sync.json
+++ b/parse/table_definitions_bsc/pancakeswap/UniswapV2Pair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve0",
+                    "type": "uint112"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve1",
+                    "type": "uint112"
+                }
+            ],
+            "name": "Sync",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "pancakeswap",
+        "table_name": "UniswapV2Pair_event_Sync",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "reserve0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reserve1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/sushiswap/UniswapV2Pair_event_Approval.json
+++ b/parse/table_definitions_bsc/sushiswap/UniswapV2Pair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "sushiswap",
+        "table_name": "UniswapV2Pair_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "value",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/sushiswap/UniswapV2Pair_event_Burn.json
+++ b/parse/table_definitions_bsc/sushiswap/UniswapV2Pair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "sushiswap",
+        "table_name": "UniswapV2Pair_event_Burn",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/sushiswap/UniswapV2Pair_event_Mint.json
+++ b/parse/table_definitions_bsc/sushiswap/UniswapV2Pair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "sushiswap",
+        "table_name": "UniswapV2Pair_event_Mint",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/sushiswap/UniswapV2Pair_event_Sync.json
+++ b/parse/table_definitions_bsc/sushiswap/UniswapV2Pair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve0",
+                    "type": "uint112"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve1",
+                    "type": "uint112"
+                }
+            ],
+            "name": "Sync",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "sushiswap",
+        "table_name": "UniswapV2Pair_event_Sync",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "reserve0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reserve1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_celo/ubeswap/UniswapV2Pair_event_Approval.json
+++ b/parse/table_definitions_celo/ubeswap/UniswapV2Pair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ubeswap",
+        "table_name": "UniswapV2Pair_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "value",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_celo/ubeswap/UniswapV2Pair_event_Burn.json
+++ b/parse/table_definitions_celo/ubeswap/UniswapV2Pair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ubeswap",
+        "table_name": "UniswapV2Pair_event_Burn",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_celo/ubeswap/UniswapV2Pair_event_Mint.json
+++ b/parse/table_definitions_celo/ubeswap/UniswapV2Pair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ubeswap",
+        "table_name": "UniswapV2Pair_event_Mint",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_celo/ubeswap/UniswapV2Pair_event_Sync.json
+++ b/parse/table_definitions_celo/ubeswap/UniswapV2Pair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve0",
+                    "type": "uint112"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve1",
+                    "type": "uint112"
+                }
+            ],
+            "name": "Sync",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ubeswap",
+        "table_name": "UniswapV2Pair_event_Sync",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "reserve0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reserve1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/spookyswap/UniswapV2Pair_event_Approval.json
+++ b/parse/table_definitions_fantom/spookyswap/UniswapV2Pair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "spookyswap",
+        "table_name": "UniswapV2Pair_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "value",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/spookyswap/UniswapV2Pair_event_Burn.json
+++ b/parse/table_definitions_fantom/spookyswap/UniswapV2Pair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "spookyswap",
+        "table_name": "UniswapV2Pair_event_Burn",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/spookyswap/UniswapV2Pair_event_Mint.json
+++ b/parse/table_definitions_fantom/spookyswap/UniswapV2Pair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "spookyswap",
+        "table_name": "UniswapV2Pair_event_Mint",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/spookyswap/UniswapV2Pair_event_Sync.json
+++ b/parse/table_definitions_fantom/spookyswap/UniswapV2Pair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve0",
+                    "type": "uint112"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve1",
+                    "type": "uint112"
+                }
+            ],
+            "name": "Sync",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "spookyswap",
+        "table_name": "UniswapV2Pair_event_Sync",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "reserve0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reserve1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/sushiswap/UniswapV2Pair_event_Approval.json
+++ b/parse/table_definitions_fantom/sushiswap/UniswapV2Pair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "sushiswap",
+        "table_name": "UniswapV2Pair_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "value",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/sushiswap/UniswapV2Pair_event_Burn.json
+++ b/parse/table_definitions_fantom/sushiswap/UniswapV2Pair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "sushiswap",
+        "table_name": "UniswapV2Pair_event_Burn",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/sushiswap/UniswapV2Pair_event_Mint.json
+++ b/parse/table_definitions_fantom/sushiswap/UniswapV2Pair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "sushiswap",
+        "table_name": "UniswapV2Pair_event_Mint",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/sushiswap/UniswapV2Pair_event_Sync.json
+++ b/parse/table_definitions_fantom/sushiswap/UniswapV2Pair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve0",
+                    "type": "uint112"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve1",
+                    "type": "uint112"
+                }
+            ],
+            "name": "Sync",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "sushiswap",
+        "table_name": "UniswapV2Pair_event_Sync",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "reserve0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reserve1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_ronin/katana/UniswapV2Pair_event_Approval.json
+++ b/parse/table_definitions_ronin/katana/UniswapV2Pair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "katana",
+        "table_name": "UniswapV2Pair_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "value",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_ronin/katana/UniswapV2Pair_event_Burn.json
+++ b/parse/table_definitions_ronin/katana/UniswapV2Pair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "katana",
+        "table_name": "UniswapV2Pair_event_Burn",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_ronin/katana/UniswapV2Pair_event_Mint.json
+++ b/parse/table_definitions_ronin/katana/UniswapV2Pair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "katana",
+        "table_name": "UniswapV2Pair_event_Mint",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_ronin/katana/UniswapV2Pair_event_Sync.json
+++ b/parse/table_definitions_ronin/katana/UniswapV2Pair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve0",
+                    "type": "uint112"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve1",
+                    "type": "uint112"
+                }
+            ],
+            "name": "Sync",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "katana",
+        "table_name": "UniswapV2Pair_event_Sync",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "reserve0",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reserve1",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This PR extends #21. Adding `UniswapV2Pair_event_{Approval,Mint,Burn,Sync}` to the other existing Dexes: 

- [x] Avalanche TraderJoe
- [x] BSC Pancakeswap
- [x] BSC Sushiswap
- [x] Celo Ubeswap
- [x] Fantom Spookyswap
- [x] Fantom Sushiswap
- [x] Ronin Katana