### PR TITLE
Add tofuNFT marketplace to Arbitrum, Avalanche, BSC and Fantom

### DIFF
--- a/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvAuctionRefund.json
+++ b/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvAuctionRefund.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x7bc8b1b5aba4df3be9f9a32dae501214dc0e4f3f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "bidder",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "refund",
+                    "type": "uint256"
+                }
+            ],
+            "name": "EvAuctionRefund",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvAuctionRefund",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bidder",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "refund",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvCouponSpent.json
+++ b/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvCouponSpent.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x7bc8b1b5aba4df3be9f9a32dae501214dc0e4f3f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "couponId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "EvCouponSpent",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvCouponSpent",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "couponId",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvInventoryUpdate.json
+++ b/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvInventoryUpdate.json
@@ -1,0 +1,85 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x7bc8b1b5aba4df3be9f9a32dae501214dc0e4f3f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "seller",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "buyer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract IERC20",
+                            "name": "currency",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "price",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "netPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "deadline",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "kind",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "status",
+                            "type": "uint8"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketNG.Inventory",
+                    "name": "inventory",
+                    "type": "tuple"
+                }
+            ],
+            "name": "EvInventoryUpdate",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvInventoryUpdate",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "inventory",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvMarketSignerUpdate.json
+++ b/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvMarketSignerUpdate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x7bc8b1b5aba4df3be9f9a32dae501214dc0e4f3f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "addr",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "isRemoval",
+                    "type": "bool"
+                }
+            ],
+            "name": "EvMarketSignerUpdate",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvMarketSignerUpdate",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "addr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "isRemoval",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvSettingsUpdated.json
+++ b/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvSettingsUpdated.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x7bc8b1b5aba4df3be9f9a32dae501214dc0e4f3f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "EvSettingsUpdated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvSettingsUpdated",
+        "table_description": "",
+        "schema": []
+    }
+}

--- a/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvSwapped.json
+++ b/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_EvSwapped.json
@@ -1,0 +1,105 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x7bc8b1b5aba4df3be9f9a32dae501214dc0e4f3f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "salt",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "creator",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "deadline",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "contract IERC721",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct MarketNG.Pair721[]",
+                            "name": "has",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "contract IERC721",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct MarketNG.Pair721[]",
+                            "name": "wants",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketNG.Swap",
+                    "name": "req",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "swapper",
+                    "type": "address"
+                }
+            ],
+            "name": "EvSwapped",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvSwapped",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "req",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "signature",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "swapper",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_OwnershipTransferred.json
+++ b/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x7bc8b1b5aba4df3be9f9a32dae501214dc0e4f3f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_OwnershipTransferred",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "previousOwner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newOwner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_Paused.json
+++ b/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_Paused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x7bc8b1b5aba4df3be9f9a32dae501214dc0e4f3f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_Paused",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "account",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_Unpaused.json
+++ b/parse/table_definitions_arbitrum/tofu_nft/MarketNG_event_Unpaused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x7bc8b1b5aba4df3be9f9a32dae501214dc0e4f3f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_Unpaused",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "account",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvAuctionRefund.json
+++ b/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvAuctionRefund.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "bidder",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "refund",
+                    "type": "uint256"
+                }
+            ],
+            "name": "EvAuctionRefund",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvAuctionRefund",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bidder",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "refund",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvCouponSpent.json
+++ b/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvCouponSpent.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "couponId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "EvCouponSpent",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvCouponSpent",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "couponId",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvInventoryUpdate.json
+++ b/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvInventoryUpdate.json
@@ -1,0 +1,85 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "seller",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "buyer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract IERC20",
+                            "name": "currency",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "price",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "netPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "deadline",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "kind",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "status",
+                            "type": "uint8"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketNG.Inventory",
+                    "name": "inventory",
+                    "type": "tuple"
+                }
+            ],
+            "name": "EvInventoryUpdate",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvInventoryUpdate",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "inventory",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvMarketSignerUpdate.json
+++ b/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvMarketSignerUpdate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "addr",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "isRemoval",
+                    "type": "bool"
+                }
+            ],
+            "name": "EvMarketSignerUpdate",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvMarketSignerUpdate",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "addr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "isRemoval",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvSettingsUpdated.json
+++ b/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvSettingsUpdated.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "EvSettingsUpdated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvSettingsUpdated",
+        "table_description": "",
+        "schema": []
+    }
+}

--- a/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvSwapped.json
+++ b/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_EvSwapped.json
@@ -1,0 +1,105 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "salt",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "creator",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "deadline",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "contract IERC721",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct MarketNG.Pair721[]",
+                            "name": "has",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "contract IERC721",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct MarketNG.Pair721[]",
+                            "name": "wants",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketNG.Swap",
+                    "name": "req",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "swapper",
+                    "type": "address"
+                }
+            ],
+            "name": "EvSwapped",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvSwapped",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "req",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "signature",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "swapper",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_OwnershipTransferred.json
+++ b/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_OwnershipTransferred",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "previousOwner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newOwner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_Paused.json
+++ b/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_Paused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_Paused",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "account",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_Unpaused.json
+++ b/parse/table_definitions_avalanche/tofu_nft/MarketNG_event_Unpaused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_Unpaused",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "account",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvAuctionRefund.json
+++ b/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvAuctionRefund.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x449d05c544601631785a7c062dcdff530330317e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "bidder",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "refund",
+                    "type": "uint256"
+                }
+            ],
+            "name": "EvAuctionRefund",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvAuctionRefund",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bidder",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "refund",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvCouponSpent.json
+++ b/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvCouponSpent.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x449d05c544601631785a7c062dcdff530330317e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "couponId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "EvCouponSpent",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvCouponSpent",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "couponId",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvInventoryUpdate.json
+++ b/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvInventoryUpdate.json
@@ -1,0 +1,85 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x449d05c544601631785a7c062dcdff530330317e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "seller",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "buyer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract IERC20",
+                            "name": "currency",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "price",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "netPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "deadline",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "kind",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "status",
+                            "type": "uint8"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketNG.Inventory",
+                    "name": "inventory",
+                    "type": "tuple"
+                }
+            ],
+            "name": "EvInventoryUpdate",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvInventoryUpdate",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "inventory",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvMarketSignerUpdate.json
+++ b/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvMarketSignerUpdate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x449d05c544601631785a7c062dcdff530330317e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "addr",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "isRemoval",
+                    "type": "bool"
+                }
+            ],
+            "name": "EvMarketSignerUpdate",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvMarketSignerUpdate",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "addr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "isRemoval",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvSettingsUpdated.json
+++ b/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvSettingsUpdated.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x449d05c544601631785a7c062dcdff530330317e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "EvSettingsUpdated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvSettingsUpdated",
+        "table_description": "",
+        "schema": []
+    }
+}

--- a/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvSwapped.json
+++ b/parse/table_definitions_bsc/tofu_nft/MarketNG_event_EvSwapped.json
@@ -1,0 +1,105 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x449d05c544601631785a7c062dcdff530330317e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "salt",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "creator",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "deadline",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "contract IERC721",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct MarketNG.Pair721[]",
+                            "name": "has",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "contract IERC721",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct MarketNG.Pair721[]",
+                            "name": "wants",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketNG.Swap",
+                    "name": "req",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "swapper",
+                    "type": "address"
+                }
+            ],
+            "name": "EvSwapped",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvSwapped",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "req",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "signature",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "swapper",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/tofu_nft/MarketNG_event_OwnershipTransferred.json
+++ b/parse/table_definitions_bsc/tofu_nft/MarketNG_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x449d05c544601631785a7c062dcdff530330317e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_OwnershipTransferred",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "previousOwner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newOwner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/tofu_nft/MarketNG_event_Paused.json
+++ b/parse/table_definitions_bsc/tofu_nft/MarketNG_event_Paused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x449d05c544601631785a7c062dcdff530330317e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_Paused",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "account",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/tofu_nft/MarketNG_event_Unpaused.json
+++ b/parse/table_definitions_bsc/tofu_nft/MarketNG_event_Unpaused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x449d05c544601631785a7c062dcdff530330317e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_Unpaused",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "account",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvAuctionRefund.json
+++ b/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvAuctionRefund.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "bidder",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "refund",
+                    "type": "uint256"
+                }
+            ],
+            "name": "EvAuctionRefund",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvAuctionRefund",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bidder",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "refund",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvCouponSpent.json
+++ b/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvCouponSpent.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "couponId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "EvCouponSpent",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvCouponSpent",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "couponId",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvInventoryUpdate.json
+++ b/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvInventoryUpdate.json
@@ -1,0 +1,85 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "seller",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "buyer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract IERC20",
+                            "name": "currency",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "price",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "netPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "deadline",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "kind",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "status",
+                            "type": "uint8"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketNG.Inventory",
+                    "name": "inventory",
+                    "type": "tuple"
+                }
+            ],
+            "name": "EvInventoryUpdate",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvInventoryUpdate",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "inventory",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvMarketSignerUpdate.json
+++ b/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvMarketSignerUpdate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "addr",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "isRemoval",
+                    "type": "bool"
+                }
+            ],
+            "name": "EvMarketSignerUpdate",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvMarketSignerUpdate",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "addr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "isRemoval",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvSettingsUpdated.json
+++ b/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvSettingsUpdated.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "EvSettingsUpdated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvSettingsUpdated",
+        "table_description": "",
+        "schema": []
+    }
+}

--- a/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvSwapped.json
+++ b/parse/table_definitions_fantom/tofu_nft/MarketNG_event_EvSwapped.json
@@ -1,0 +1,105 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "salt",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "creator",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "deadline",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "contract IERC721",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct MarketNG.Pair721[]",
+                            "name": "has",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "contract IERC721",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct MarketNG.Pair721[]",
+                            "name": "wants",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketNG.Swap",
+                    "name": "req",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "swapper",
+                    "type": "address"
+                }
+            ],
+            "name": "EvSwapped",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_EvSwapped",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "req",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "signature",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "swapper",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/tofu_nft/MarketNG_event_OwnershipTransferred.json
+++ b/parse/table_definitions_fantom/tofu_nft/MarketNG_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_OwnershipTransferred",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "previousOwner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newOwner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/tofu_nft/MarketNG_event_Paused.json
+++ b/parse/table_definitions_fantom/tofu_nft/MarketNG_event_Paused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_Paused",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "account",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_fantom/tofu_nft/MarketNG_event_Unpaused.json
+++ b/parse/table_definitions_fantom/tofu_nft/MarketNG_event_Unpaused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x86232f68b5bf2a3a03851d98556352512a3b12b9",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "tofu_nft",
+        "table_name": "MarketNG_event_Unpaused",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "account",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Add the tofuNFT marketplace across several chains.

For now I only need Arbitrum, but the other chains will follow sooner or later. Let me know if I should reduce this to only Arbitrum and add the others as needed later on