### PR TITLE
ApeSwap UniswapV2 & MasterChef events

### DIFF
--- a/parse/table_definitions_bsc/apeswap/ApeFactory_event_PairCreated.json
+++ b/parse/table_definitions_bsc/apeswap/ApeFactory_event_PairCreated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token0",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token1",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "pair",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PairCreated",
+            "type": "event"
+        },
+        "contract_address": "0x0841bd0b734e4f5853f0dd8d7ea041c241fb0da6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "token0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pair",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ApeFactory_event_PairCreated"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/ApePair_event_Approval.json
+++ b/parse/table_definitions_bsc/apeswap/ApePair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('ApeFactory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ApePair_event_Approval"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/ApePair_event_Burn.json
+++ b/parse/table_definitions_bsc/apeswap/ApePair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('ApeFactory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ApePair_event_Burn"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/ApePair_event_Mint.json
+++ b/parse/table_definitions_bsc/apeswap/ApePair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('ApeFactory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ApePair_event_Mint"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/ApePair_event_Swap.json
+++ b/parse/table_definitions_bsc/apeswap/ApePair_event_Swap.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0In",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1In",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0Out",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1Out",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Swap",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('ApeFactory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0In",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1In",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0Out",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1Out",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ApePair_event_Swap"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/ApePair_event_Sync.json
+++ b/parse/table_definitions_bsc/apeswap/ApePair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve0",
+                    "type": "uint112"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve1",
+                    "type": "uint112"
+                }
+            ],
+            "name": "Sync",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('ApeFactory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reserve1",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ApePair_event_Sync"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/ApePair_event_Transfer.json
+++ b/parse/table_definitions_bsc/apeswap/ApePair_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('ApeFactory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ApePair_event_Transfer"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_AddFarm.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_AddFarm.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20",
+                    "name": "lpToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "allocation",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AddFarm",
+            "type": "event"
+        },
+        "contract_address": "0x9fed2bc7f0b4f4350b52e29e0a3c2bf5ebc3cc0a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "lpToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "allocation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApeAdmin_event_AddFarm"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_AddFixedPercentFarm.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_AddFixedPercentFarm.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "pid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "allocationPercentage",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AddFixedPercentFarm",
+            "type": "event"
+        },
+        "contract_address": "0x9fed2bc7f0b4f4350b52e29e0a3c2bf5ebc3cc0a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "allocationPercentage",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApeAdmin_event_AddFixedPercentFarm"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_OwnershipTransferred.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x9fed2bc7f0b4f4350b52e29e0a3c2bf5ebc3cc0a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApeAdmin_event_OwnershipTransferred"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SetFarm.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SetFarm.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "pid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "allocation",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SetFarm",
+            "type": "event"
+        },
+        "contract_address": "0x9fed2bc7f0b4f4350b52e29e0a3c2bf5ebc3cc0a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "allocation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApeAdmin_event_SetFarm"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SetFixedPercentFarm.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SetFixedPercentFarm.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "pid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "previousAllocationPercentage",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "allocationPercentage",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SetFixedPercentFarm",
+            "type": "event"
+        },
+        "contract_address": "0x9fed2bc7f0b4f4350b52e29e0a3c2bf5ebc3cc0a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "previousAllocationPercentage",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "allocationPercentage",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApeAdmin_event_SetFixedPercentFarm"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SetPendingMasterApeOwner.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SetPendingMasterApeOwner.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "pendingMasterApeOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "SetPendingMasterApeOwner",
+            "type": "event"
+        },
+        "contract_address": "0x9fed2bc7f0b4f4350b52e29e0a3c2bf5ebc3cc0a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "pendingMasterApeOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApeAdmin_event_SetPendingMasterApeOwner"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SweepWithdraw.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SweepWithdraw.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SweepWithdraw",
+            "type": "event"
+        },
+        "contract_address": "0x9fed2bc7f0b4f4350b52e29e0a3c2bf5ebc3cc0a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApeAdmin_event_SweepWithdraw"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SyncFixedPercentFarm.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_SyncFixedPercentFarm.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "pid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "allocation",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SyncFixedPercentFarm",
+            "type": "event"
+        },
+        "contract_address": "0x9fed2bc7f0b4f4350b52e29e0a3c2bf5ebc3cc0a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "allocation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApeAdmin_event_SyncFixedPercentFarm"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_TransferredFarmAdmin.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApeAdmin_event_TransferredFarmAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousFarmAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newFarmAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "TransferredFarmAdmin",
+            "type": "event"
+        },
+        "contract_address": "0x9fed2bc7f0b4f4350b52e29e0a3c2bf5ebc3cc0a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousFarmAdmin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFarmAdmin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApeAdmin_event_TransferredFarmAdmin"
+    }
+}


### PR DESCRIPTION
This PR adds events that cover the UniswapV2 and MasterChef components of ApeSwap. Unlike many projects the contract names were changed from e.g. UniswapV2Factory to ApeFactory and from MasterChef to MasterApe.

This change means there is some shim logic to use these events in downstream ETLs that can take Uniswap/Sushi shaped inputs. It is presumably better to respect the contract names than to ignore it for the sake of downstream compatibility. But thoughts on precedent are welcome here.

ApeSwap docs: https://apeswap.gitbook.io/apeswap-finance/where-dev/smart-contracts

fyi @medvedev1088