### PR TITLE
ApeSwap MasterChef add()/set() calls

### DIFF
--- a/parse/table_definitions_bsc/apeswap/MasterApe_call_add.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApe_call_add.json
@@ -1,0 +1,52 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_allocPoint",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "contract IBEP20",
+                    "name": "_lpToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "_withUpdate",
+                    "type": "bool"
+                }
+            ],
+            "name": "add",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x5c8d727b265dbafaba67e050f2f739caeeb4a6f9",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "_allocPoint",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_lpToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_withUpdate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApe_call_add"
+    }
+}

--- a/parse/table_definitions_bsc/apeswap/MasterApe_call_set.json
+++ b/parse/table_definitions_bsc/apeswap/MasterApe_call_set.json
@@ -1,0 +1,52 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_pid",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_allocPoint",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "_withUpdate",
+                    "type": "bool"
+                }
+            ],
+            "name": "set",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x5c8d727b265dbafaba67e050f2f739caeeb4a6f9",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "apeswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "_pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_allocPoint",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_withUpdate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MasterApe_call_set"
+    }
+}


### PR DESCRIPTION
This PR adds tables for calls to `add` and `set` which adds new farms and sets their incentive allocation. This is the first time I've added tables for calls instead of events so pardon any errors. I based this on examples I've seen elsewhere as https://nansen-contract-parser-prod.web.app/ left several template variables not filled out.

cc @medvedev1088 