### PR TITLE
add Benqi Comptroller

### DIFF
--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_ActionPaused.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_ActionPaused.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "action",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "pauseState",
+                    "type": "bool"
+                }
+            ],
+            "name": "ActionPaused",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "action",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pauseState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_ActionPaused"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_ActionPaused.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_ActionPaused.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_BorrowRewardSpeedUpdated.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_BorrowRewardSpeedUpdated.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_BorrowRewardSpeedUpdated.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_BorrowRewardSpeedUpdated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "rewardToken",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowRewardSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowRewardSpeedUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "rewardToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowRewardSpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_BorrowRewardSpeedUpdated"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_ContributorQiSpeedUpdated.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_ContributorQiSpeedUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "contributor",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ContributorQiSpeedUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "contributor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_ContributorQiSpeedUpdated"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_ContributorQiSpeedUpdated.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_ContributorQiSpeedUpdated.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_DistributedBorrowerReward.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_DistributedBorrowerReward.json
@@ -42,7 +42,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_DistributedBorrowerReward.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_DistributedBorrowerReward.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint8",
+                    "name": "tokenType",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "qiDelta",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "qiBorrowIndex",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DistributedBorrowerReward",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "tokenType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "qiDelta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "qiBorrowIndex",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_DistributedBorrowerReward"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_DistributedSupplierReward.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_DistributedSupplierReward.json
@@ -42,7 +42,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_DistributedSupplierReward.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_DistributedSupplierReward.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint8",
+                    "name": "tokenType",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "qiDelta",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "qiBorrowIndex",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DistributedSupplierReward",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "tokenType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "qiDelta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "qiBorrowIndex",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_DistributedSupplierReward"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_Failure.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_Failure.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_Failure.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_Failure.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "error",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "info",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "detail",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_Failure"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketEntered.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketEntered.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketEntered",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_MarketEntered"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketEntered.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketEntered.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketExited.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketExited.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketExited",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_MarketExited"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketExited.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketExited.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketListed.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketListed.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketListed",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_MarketListed"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketListed.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_MarketListed.json
@@ -18,7 +18,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewBorrowCap.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewBorrowCap.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewBorrowCap",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewBorrowCap"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewBorrowCap.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewBorrowCap.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewBorrowCapGuardian.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewBorrowCapGuardian.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldBorrowCapGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newBorrowCapGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "NewBorrowCapGuardian",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldBorrowCapGuardian",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCapGuardian",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewBorrowCapGuardian"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewBorrowCapGuardian.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewBorrowCapGuardian.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewCloseFactor.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewCloseFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCloseFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCloseFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCloseFactor",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldCloseFactorMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCloseFactorMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewCloseFactor"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewCloseFactor.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewCloseFactor.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewCollateralFactor.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewCollateralFactor.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewCollateralFactor.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewCollateralFactor.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCollateralFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCollateralFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCollateralFactor",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldCollateralFactorMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCollateralFactorMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewCollateralFactor"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewLiquidationIncentive.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewLiquidationIncentive.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewLiquidationIncentive",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldLiquidationIncentiveMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newLiquidationIncentiveMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewLiquidationIncentive"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewLiquidationIncentive.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewLiquidationIncentive.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewPauseGuardian.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewPauseGuardian.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewPauseGuardian.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewPauseGuardian.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPauseGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPauseGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPauseGuardian",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldPauseGuardian",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPauseGuardian",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewPauseGuardian"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewPriceOracle.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewPriceOracle.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract PriceOracle",
+                    "name": "oldPriceOracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract PriceOracle",
+                    "name": "newPriceOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPriceOracle",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldPriceOracle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPriceOracle",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewPriceOracle"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_NewPriceOracle.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_NewPriceOracle.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_QiGranted.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_QiGranted.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "QiGranted",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_QiGranted"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_QiGranted.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_QiGranted.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_SupplyRewardSpeedUpdated.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_SupplyRewardSpeedUpdated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "rewardToken",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSupplyRewardSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyRewardSpeedUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xd8e426c61b0fbbda06e9f603263abea09d717dbd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "avalanche_benqi",
+        "schema": [
+            {
+                "description": "",
+                "name": "rewardToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "qiToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyRewardSpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_SupplyRewardSpeedUpdated"
+    }
+}

--- a/parse/table_definitions_avalanche/benqi/Comptroller_event_SupplyRewardSpeedUpdated.json
+++ b/parse/table_definitions_avalanche/benqi/Comptroller_event_SupplyRewardSpeedUpdated.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "avalanche_benqi",
+        "dataset_name": "benqi",
         "schema": [
             {
                 "description": "",


### PR DESCRIPTION
Adds all 18 events from the Benqi Comptroller to blockchain-etl.

Generated via https://nansen-contract-parser-prod.web.app/ on address 0xd8E426C61b0FBBda06e9F603263ABea09d717dBD on Avalanche chain.