### PR TITLE
Optimism Synthetix table definitions

### DIFF
--- a/parse/table_definitions_optimism/synthetix/Synth_event_Approval.json
+++ b/parse/table_definitions_optimism/synthetix/Synth_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9', '0xfbc4198702e81ae77c06d58f81b629bdf36f0a71', '0xa3a538ea5d5838dc32dde15946ccd74bdd5652ff', '0x298b9b95708152ff6968aafd889c6586e9169f1d', '0xe405de8f52ba7559f9df3c368500b6e6ae6cee49', '0xc5db22719a06418028a40a9b5e9a7c02959d0d08', '0x00b8d5a5e1ac97cb4341c4bc4367443c8776e8d9', '0x8b2f7ae8ca8ee8428b6d76de88326bb413db2766', '0xb2b42b231c68cbb0b4bf2ffebf57782fd97d3da4', '0x81ddfac111913d3d5218dea999216323b7cd6356', '0xf5a6115aa582fd1beea22bc93b7dc7a785f60d03'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_Approval"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synth_event_OwnerChanged.json
+++ b/parse/table_definitions_optimism/synthetix/Synth_event_OwnerChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerChanged",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9', '0xfbc4198702e81ae77c06d58f81b629bdf36f0a71', '0xa3a538ea5d5838dc32dde15946ccd74bdd5652ff', '0x298b9b95708152ff6968aafd889c6586e9169f1d', '0xe405de8f52ba7559f9df3c368500b6e6ae6cee49', '0xc5db22719a06418028a40a9b5e9a7c02959d0d08', '0x00b8d5a5e1ac97cb4341c4bc4367443c8776e8d9', '0x8b2f7ae8ca8ee8428b6d76de88326bb413db2766', '0xb2b42b231c68cbb0b4bf2ffebf57782fd97d3da4', '0x81ddfac111913d3d5218dea999216323b7cd6356', '0xf5a6115aa582fd1beea22bc93b7dc7a785f60d03'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_OwnerChanged"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synth_event_OwnerNominated.json
+++ b/parse/table_definitions_optimism/synthetix/Synth_event_OwnerNominated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerNominated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9', '0xfbc4198702e81ae77c06d58f81b629bdf36f0a71', '0xa3a538ea5d5838dc32dde15946ccd74bdd5652ff', '0x298b9b95708152ff6968aafd889c6586e9169f1d', '0xe405de8f52ba7559f9df3c368500b6e6ae6cee49', '0xc5db22719a06418028a40a9b5e9a7c02959d0d08', '0x00b8d5a5e1ac97cb4341c4bc4367443c8776e8d9', '0x8b2f7ae8ca8ee8428b6d76de88326bb413db2766', '0xb2b42b231c68cbb0b4bf2ffebf57782fd97d3da4', '0x81ddfac111913d3d5218dea999216323b7cd6356', '0xf5a6115aa582fd1beea22bc93b7dc7a785f60d03'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_OwnerNominated"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synth_event_TargetUpdated.json
+++ b/parse/table_definitions_optimism/synthetix/Synth_event_TargetUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract Proxyable",
+                    "name": "newTarget",
+                    "type": "address"
+                }
+            ],
+            "name": "TargetUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9', '0xfbc4198702e81ae77c06d58f81b629bdf36f0a71', '0xa3a538ea5d5838dc32dde15946ccd74bdd5652ff', '0x298b9b95708152ff6968aafd889c6586e9169f1d', '0xe405de8f52ba7559f9df3c368500b6e6ae6cee49', '0xc5db22719a06418028a40a9b5e9a7c02959d0d08', '0x00b8d5a5e1ac97cb4341c4bc4367443c8776e8d9', '0x8b2f7ae8ca8ee8428b6d76de88326bb413db2766', '0xb2b42b231c68cbb0b4bf2ffebf57782fd97d3da4', '0x81ddfac111913d3d5218dea999216323b7cd6356', '0xf5a6115aa582fd1beea22bc93b7dc7a785f60d03'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newTarget",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_TargetUpdated"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synth_event_Transfer.json
+++ b/parse/table_definitions_optimism/synthetix/Synth_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9', '0xfbc4198702e81ae77c06d58f81b629bdf36f0a71', '0xa3a538ea5d5838dc32dde15946ccd74bdd5652ff', '0x298b9b95708152ff6968aafd889c6586e9169f1d', '0xe405de8f52ba7559f9df3c368500b6e6ae6cee49', '0xc5db22719a06418028a40a9b5e9a7c02959d0d08', '0x00b8d5a5e1ac97cb4341c4bc4367443c8776e8d9', '0x8b2f7ae8ca8ee8428b6d76de88326bb413db2766', '0xb2b42b231c68cbb0b4bf2ffebf57782fd97d3da4', '0x81ddfac111913d3d5218dea999216323b7cd6356', '0xf5a6115aa582fd1beea22bc93b7dc7a785f60d03'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_Transfer"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_Approval.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_Approval"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_OwnerChanged.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_OwnerChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_OwnerChanged"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_OwnerNominated.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_OwnerNominated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerNominated",
+            "type": "event"
+        },
+        "contract_address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_OwnerNominated"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_TargetUpdated.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_TargetUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract Proxyable",
+                    "name": "newTarget",
+                    "type": "address"
+                }
+            ],
+            "name": "TargetUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newTarget",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_TargetUpdated"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_Transfer.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_Transfer"
+    }
+}


### PR DESCRIPTION
## What?
Add support for contract events from the Synthetix contract (SNX token) and Synth contracts (sUSD, sEUR, sINR, sBTC, sETH, sLINK, sAAVE, sSOL, sAVAX, sMATIC, sUNI) on Optimism.

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions, and grouped together the Synths. Contract addresses are from https://docs.synthetix.io/addresses/#mainnet-optimism-l2. 