### PR TITLE
aave v3: variable & stable debt tokens

### DIFF
--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Approval"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Burn.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Burn"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Initialized"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Mint.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Mint"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Transfer"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Approval"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Burn.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "target",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "target",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Burn"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Initialized"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Mint.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Mint"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Transfer"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Approval"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Burn.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Burn"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Initialized"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Mint.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Mint"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Transfer"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Approval"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Burn.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "target",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "target",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Burn"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Initialized"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Mint.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Mint"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Transfer"
+    }
+}

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Approval"
+    }
+}

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Burn.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Burn"
+    }
+}

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Initialized"
+    }
+}

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Mint.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Mint"
+    }
+}

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Transfer"
+    }
+}

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x77ca01483f379e58174739308945f044e1a764dc', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Approval"
+    }
+}

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x77ca01483f379e58174739308945f044e1a764dc', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Burn.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "target",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x77ca01483f379e58174739308945f044e1a764dc', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "target",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Burn"
+    }
+}

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Initialized"
+    }
+}

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Mint.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Mint"
+    }
+}

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x77ca01483f379e58174739308945f044e1a764dc', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Transfer"
+    }
+}

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Approval"
+    }
+}

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Burn.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Burn"
+    }
+}

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Initialized"
+    }
+}

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Mint.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Mint"
+    }
+}

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Transfer"
+    }
+}

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Approval"
+    }
+}

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Burn.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "target",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "target",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Burn"
+    }
+}

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Initialized"
+    }
+}

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Mint.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Mint"
+    }
+}

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Transfer"
+    }
+}


### PR DESCRIPTION
What?
Add support for Aave v3 variable & stable debt tokens events

How?
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions.