### PR TITLE
AccountLiquidated event for Synthetix on Optimism

### DIFF
--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountLiquidated.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountLiquidated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "snxRedeemed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountLiquidated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "liquidator",
+                    "type": "address"
+                }
+            ],
+            "name": "AccountLiquidated",
+            "type": "event"
+        },
+        "contract_address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "snxRedeemed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountLiquidated",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidator",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_AccountLiquidated"
+    }
+}


### PR DESCRIPTION
## What?
Added support for the AccountLiquidated event for Synthetix on Optimism

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions using the underlying MintableSynthetix contract as input ([0xFE8E48Bf36ccC3254081eC8C65965D1c8b2E744D](https://optimistic.etherscan.io/address/0xFE8E48Bf36ccC3254081eC8C65965D1c8b2E744D)), but replaced the contract address with the ProxyERC20 contract ([0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4)](https://optimistic.etherscan.io/address/0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4)) which [should be emitting this event](https://github.com/Synthetixio/synthetix/blob/a9189241eebddb74fb6f6a222c749f569241d997/contracts/BaseSynthetix.sol#L521) (e.g. [this tx](https://optimistic.etherscan.io/tx/19446146#eventlog)).