### PR TITLE
Fix table definitions for Ronin Axie events

### DIFF
--- a/parse/table_definitions_ronin/axie/Axie_event_AxieEvolved.json
+++ b/parse/table_definitions_ronin/axie/Axie_event_AxieEvolved.json
@@ -46,7 +46,17 @@
             {
                 "description": "",
                 "name": "_genes",
-                "type": "STRING"
+                "type": "RECORD",
+                "fields": [
+                    {
+                        "name": "x",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "y",
+                        "type": "STRING"
+                    }
+                ]
             }
         ],
         "table_description": "",

--- a/parse/table_definitions_ronin/axie/Axie_event_AxieMinted.json
+++ b/parse/table_definitions_ronin/axie/Axie_event_AxieMinted.json
@@ -78,7 +78,43 @@
             {
                 "description": "",
                 "name": "_axie",
-                "type": "STRING"
+                "type": "RECORD",
+                "fields": [
+                    {
+                        "name": "sireId",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "matronId",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "birthDate",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "genes",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "y",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "breedCount",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "level",
+                        "type": "STRING"
+                    }
+                ]
             }
         ],
         "table_description": "",

--- a/parse/table_definitions_ronin/axie/Axie_event_AxieggMinted.json
+++ b/parse/table_definitions_ronin/axie/Axie_event_AxieggMinted.json
@@ -120,12 +120,78 @@
             {
                 "description": "",
                 "name": "_axie",
-                "type": "STRING"
+                "type": "RECORD",
+                "fields": [
+                    {
+                        "name": "sireId",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "matronId",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "birthDate",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "genes",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "y",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "breedCount",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "level",
+                        "type": "STRING"
+                    }
+                ]
             },
             {
                 "description": "",
                 "name": "_axiegg",
-                "type": "STRING"
+                "type": "RECORD",
+                "fields": [
+                    {
+                        "name": "sireGenes",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "y",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "matronGenes",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "x",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "y",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                ]
             }
         ],
         "table_description": "",

--- a/parse/table_definitions_ronin/axie/Gateway_v2_event_Deposited.json
+++ b/parse/table_definitions_ronin/axie/Gateway_v2_event_Deposited.json
@@ -112,7 +112,71 @@
             {
                 "description": "",
                 "name": "receipt",
-                "type": "STRING"
+                "type": "RECORD",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "kind",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "mainchain",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "addr",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "tokenAddr",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "chainId",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ronin",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "addr",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "tokenAddr",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "chainId",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "info",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "erc",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "id",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "quantity",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                ]
             }
         ],
         "table_description": "",

--- a/parse/table_definitions_ronin/axie/Gateway_v2_event_MainchainWithdrew.json
+++ b/parse/table_definitions_ronin/axie/Gateway_v2_event_MainchainWithdrew.json
@@ -112,7 +112,71 @@
           {
               "description": "",
               "name": "receipt",
-              "type": "STRING"
+              "type": "RECORD",
+              "fields": [
+                  {
+                      "name": "id",
+                      "type": "STRING"
+                  },
+                  {
+                      "name": "kind",
+                      "type": "STRING"
+                  },
+                  {
+                      "name": "mainchain",
+                      "type": "RECORD",
+                      "fields": [
+                          {
+                              "name": "addr",
+                              "type": "STRING"
+                          },
+                          {
+                              "name": "tokenAddr",
+                              "type": "STRING"
+                          },
+                          {
+                              "name": "chainId",
+                              "type": "STRING"
+                          }
+                      ]
+                  },
+                  {
+                      "name": "ronin",
+                      "type": "RECORD",
+                      "fields": [
+                          {
+                              "name": "addr",
+                              "type": "STRING"
+                          },
+                          {
+                              "name": "tokenAddr",
+                              "type": "STRING"
+                          },
+                          {
+                              "name": "chainId",
+                              "type": "STRING"
+                          }
+                      ]
+                  },
+                  {
+                      "name": "info",
+                      "type": "RECORD",
+                      "fields": [
+                          {
+                              "name": "erc",
+                              "type": "STRING"
+                          },
+                          {
+                              "name": "id",
+                              "type": "STRING"
+                          },
+                          {
+                              "name": "quantity",
+                              "type": "STRING"
+                          }
+                      ]
+                  }
+              ]
           }
         ],
         "table_description": "",


### PR DESCRIPTION
The BigQuery UDF we use to parse events recursively processes tuples, and turns them into Javascript Objects. If the target column in BigQuery is defined as a STRING, the UDF ultimately calls .toString() on this object, which returns "[object Object]" instead of a useful representation. We can fix this by providing a full schema for these objects.
