### PR TITLE
Add Seaport table definitions

### DIFF
--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_cancel.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_cancel.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_cancel.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_cancel.json
@@ -1,0 +1,154 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "zone",
+                            "type": "address"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OfferItem[]",
+                            "name": "offer",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ConsiderationItem[]",
+                            "name": "consideration",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "enum OrderType",
+                            "name": "orderType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "zoneHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "counter",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct OrderComponents[]",
+                    "name": "orders",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "cancel",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "cancelled",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_cancel",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orders",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAdvancedOrder.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAdvancedOrder.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAdvancedOrder.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAdvancedOrder.json
@@ -1,0 +1,238 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "numerator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "denominator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "extraData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct AdvancedOrder",
+                    "name": "advancedOrder",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum Side",
+                            "name": "side",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "index",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32[]",
+                            "name": "criteriaProof",
+                            "type": "bytes32[]"
+                        }
+                    ],
+                    "internalType": "struct CriteriaResolver[]",
+                    "name": "criteriaResolvers",
+                    "type": "tuple[]"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "fulfillerConduitKey",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                }
+            ],
+            "name": "fulfillAdvancedOrder",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "fulfilled",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_fulfillAdvancedOrder",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "advancedOrder",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "criteriaResolvers",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fulfillerConduitKey",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAvailableAdvancedOrders.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAvailableAdvancedOrders.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAvailableAdvancedOrders.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAvailableAdvancedOrders.json
@@ -1,0 +1,341 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "numerator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "denominator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "extraData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct AdvancedOrder[]",
+                    "name": "advancedOrders",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum Side",
+                            "name": "side",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "index",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32[]",
+                            "name": "criteriaProof",
+                            "type": "bytes32[]"
+                        }
+                    ],
+                    "internalType": "struct CriteriaResolver[]",
+                    "name": "criteriaResolvers",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "itemIndex",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct FulfillmentComponent[][]",
+                    "name": "offerFulfillments",
+                    "type": "tuple[][]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "itemIndex",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct FulfillmentComponent[][]",
+                    "name": "considerationFulfillments",
+                    "type": "tuple[][]"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "fulfillerConduitKey",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "maximumFulfilled",
+                    "type": "uint256"
+                }
+            ],
+            "name": "fulfillAvailableAdvancedOrders",
+            "outputs": [
+                {
+                    "internalType": "bool[]",
+                    "name": "availableOrders",
+                    "type": "bool[]"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifier",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ReceivedItem",
+                            "name": "item",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct Execution[]",
+                    "name": "executions",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_fulfillAvailableAdvancedOrders",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "advancedOrders",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "criteriaResolvers",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerFulfillments",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "considerationFulfillments",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fulfillerConduitKey",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maximumFulfilled",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAvailableOrders.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAvailableOrders.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAvailableOrders.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillAvailableOrders.json
@@ -1,0 +1,279 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct Order[]",
+                    "name": "orders",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "itemIndex",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct FulfillmentComponent[][]",
+                    "name": "offerFulfillments",
+                    "type": "tuple[][]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "itemIndex",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct FulfillmentComponent[][]",
+                    "name": "considerationFulfillments",
+                    "type": "tuple[][]"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "fulfillerConduitKey",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "maximumFulfilled",
+                    "type": "uint256"
+                }
+            ],
+            "name": "fulfillAvailableOrders",
+            "outputs": [
+                {
+                    "internalType": "bool[]",
+                    "name": "availableOrders",
+                    "type": "bool[]"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifier",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ReceivedItem",
+                            "name": "item",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct Execution[]",
+                    "name": "executions",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_fulfillAvailableOrders",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orders",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerFulfillments",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "considerationFulfillments",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fulfillerConduitKey",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maximumFulfilled",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillBasicOrder.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillBasicOrder.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillBasicOrder.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillBasicOrder.json
@@ -1,0 +1,142 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "considerationToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "considerationIdentifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "considerationAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "zone",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "offerIdentifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "offerAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum BasicOrderType",
+                            "name": "basicOrderType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "zoneHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "offererConduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "fulfillerConduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalOriginalAdditionalRecipients",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct AdditionalRecipient[]",
+                            "name": "additionalRecipients",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BasicOrderParameters",
+                    "name": "parameters",
+                    "type": "tuple"
+                }
+            ],
+            "name": "fulfillBasicOrder",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "fulfilled",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_fulfillBasicOrder",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "parameters",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillOrder.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillOrder.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillOrder.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_fulfillOrder.json
@@ -1,0 +1,176 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct Order",
+                    "name": "order",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "fulfillerConduitKey",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "fulfillOrder",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "fulfilled",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_fulfillOrder",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "order",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fulfillerConduitKey",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_getCounter.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_getCounter.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_getCounter.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_getCounter.json
@@ -1,0 +1,38 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "getCounter",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "counter",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_getCounter",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_getOrderHash.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_getOrderHash.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_getOrderHash.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_getOrderHash.json
@@ -1,0 +1,154 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "zone",
+                            "type": "address"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OfferItem[]",
+                            "name": "offer",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ConsiderationItem[]",
+                            "name": "consideration",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "enum OrderType",
+                            "name": "orderType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "zoneHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "counter",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct OrderComponents",
+                    "name": "order",
+                    "type": "tuple"
+                }
+            ],
+            "name": "getOrderHash",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_getOrderHash",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "order",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_getOrderStatus.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_getOrderStatus.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_getOrderStatus.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_getOrderStatus.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getOrderStatus",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "isValidated",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "isCancelled",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "totalFilled",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "totalSize",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_getOrderStatus",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_incrementCounter.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_incrementCounter.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [],
             "name": "incrementCounter",

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_incrementCounter.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_incrementCounter.json
@@ -1,0 +1,26 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [],
+            "name": "incrementCounter",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_incrementCounter",
+        "table_description": "",
+        "schema": []
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_information.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_information.json
@@ -1,0 +1,36 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [],
+            "name": "information",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "domainSeparator",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "address",
+                    "name": "conduitController",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_information",
+        "table_description": "",
+        "schema": []
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_information.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_information.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [],
             "name": "information",

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_matchAdvancedOrders.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_matchAdvancedOrders.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_matchAdvancedOrders.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_matchAdvancedOrders.json
@@ -1,0 +1,308 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "numerator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "denominator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "extraData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct AdvancedOrder[]",
+                    "name": "advancedOrders",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum Side",
+                            "name": "side",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "index",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32[]",
+                            "name": "criteriaProof",
+                            "type": "bytes32[]"
+                        }
+                    ],
+                    "internalType": "struct CriteriaResolver[]",
+                    "name": "criteriaResolvers",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "orderIndex",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "itemIndex",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct FulfillmentComponent[]",
+                            "name": "offerComponents",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "orderIndex",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "itemIndex",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct FulfillmentComponent[]",
+                            "name": "considerationComponents",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "internalType": "struct Fulfillment[]",
+                    "name": "fulfillments",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "matchAdvancedOrders",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifier",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ReceivedItem",
+                            "name": "item",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct Execution[]",
+                    "name": "executions",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_matchAdvancedOrders",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "advancedOrders",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "criteriaResolvers",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fulfillments",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_matchOrders.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_matchOrders.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_matchOrders.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_matchOrders.json
@@ -1,0 +1,256 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct Order[]",
+                    "name": "orders",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "orderIndex",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "itemIndex",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct FulfillmentComponent[]",
+                            "name": "offerComponents",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "orderIndex",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "itemIndex",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct FulfillmentComponent[]",
+                            "name": "considerationComponents",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "internalType": "struct Fulfillment[]",
+                    "name": "fulfillments",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "matchOrders",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifier",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ReceivedItem",
+                            "name": "item",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct Execution[]",
+                    "name": "executions",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_matchOrders",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orders",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fulfillments",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_name.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_name.json
@@ -1,0 +1,26 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "contractName",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_name",
+        "table_description": "",
+        "schema": []
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_name.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_name.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [],
             "name": "name",

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_validate.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_validate.json
@@ -1,0 +1,166 @@
+{
+    "parser": {
+        "type": "trace",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct Order[]",
+                    "name": "orders",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "validate",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "validated",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_call_validate",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orders",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_call_validate.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_call_validate.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "trace",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "inputs": [
                 {

--- a/parse/table_definitions_arbitrum/seaport/Seaport_event_CounterIncremented.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_event_CounterIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "CounterIncremented",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_event_CounterIncremented",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "newCounter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_event_CounterIncremented.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_event_CounterIncremented.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderCancelled.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderCancelled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_event_OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderCancelled.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderCancelled.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderFulfilled.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderFulfilled.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct SpentItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct ReceivedItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "OrderFulfilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_event_OrderFulfilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "consideration",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderFulfilled.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderFulfilled.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderValidated.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderValidated.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderValidated.json
+++ b/parse/table_definitions_arbitrum/seaport/Seaport_event_OrderValidated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x0000000000ffe8b47b3e2130213b802212439497",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderValidated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "Seaport_event_OrderValidated",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## What?
Add Seaport table definitions. They supposedly launch tomorrow, 21st of September: https://twitter.com/opensea/status/1572250900198203392

## How? 
I used the cli-tools
