### PR TITLE
add Venus Comptroller events

### DIFF
--- a/parse/table_definitions_bsc/venus/Comptroller_event_ActionPaused.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_ActionPaused.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract VToken",
+                    "name": "vToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "action",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "pauseState",
+                    "type": "bool"
+                }
+            ],
+            "name": "ActionPaused",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "vToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "action",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pauseState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_ActionPaused"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_ActionPaused.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_ActionPaused.json
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_ActionPaused"
+        "table_name": "Comptroller_event_ActionPaused"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_ActionPaused.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_ActionPaused.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_ActionProtocolPaused.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_ActionProtocolPaused.json
@@ -18,7 +18,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_ActionProtocolPaused.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_ActionProtocolPaused.json
@@ -27,6 +27,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_ActionProtocolPaused"
+        "table_name": "Comptroller_event_ActionProtocolPaused"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_ActionProtocolPaused.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_ActionProtocolPaused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "state",
+                    "type": "bool"
+                }
+            ],
+            "name": "ActionProtocolPaused",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "state",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_ActionProtocolPaused"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_DistributedBorrowerVenus.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_DistributedBorrowerVenus.json
@@ -60,6 +60,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_DistributedBorrowerVenus"
+        "table_name": "Comptroller_event_DistributedBorrowerVenus"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_DistributedBorrowerVenus.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_DistributedBorrowerVenus.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_DistributedBorrowerVenus.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_DistributedBorrowerVenus.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract VToken",
+                    "name": "vToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "venusDelta",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "venusBorrowIndex",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DistributedBorrowerVenus",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "vToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "venusDelta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "venusBorrowIndex",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_DistributedBorrowerVenus"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_DistributedSupplierVenus.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_DistributedSupplierVenus.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_DistributedSupplierVenus.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_DistributedSupplierVenus.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract VToken",
+                    "name": "vToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "supplier",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "venusDelta",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "venusSupplyIndex",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DistributedSupplierVenus",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "vToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "supplier",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "venusDelta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "venusSupplyIndex",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_DistributedSupplierVenus"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_DistributedSupplierVenus.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_DistributedSupplierVenus.json
@@ -60,6 +60,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_DistributedSupplierVenus"
+        "table_name": "Comptroller_event_DistributedSupplierVenus"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_Failure.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_Failure.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "error",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "info",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "detail",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_Failure"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_Failure.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_Failure.json
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_Failure"
+        "table_name": "Comptroller_event_Failure"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_Failure.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_Failure.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketEntered.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketEntered.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_MarketEntered"
+        "table_name": "Comptroller_event_MarketEntered"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketEntered.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketEntered.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketEntered.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketEntered.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract VToken",
+                    "name": "vToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketEntered",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "vToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_MarketEntered"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketExited.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketExited.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_MarketExited"
+        "table_name": "Comptroller_event_MarketExited"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketExited.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketExited.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract VToken",
+                    "name": "vToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketExited",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "vToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_MarketExited"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketExited.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketExited.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketListed.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketListed.json
@@ -18,7 +18,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketListed.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketListed.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract VToken",
+                    "name": "vToken",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketListed",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "vToken",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_MarketListed"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketListed.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketListed.json
@@ -27,6 +27,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_MarketListed"
+        "table_name": "Comptroller_event_MarketListed"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketVenus.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketVenus.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_MarketVenus"
+        "table_name": "Comptroller_event_MarketVenus"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketVenus.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketVenus.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_MarketVenus.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_MarketVenus.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract VToken",
+                    "name": "vToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "isVenus",
+                    "type": "bool"
+                }
+            ],
+            "name": "MarketVenus",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "vToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isVenus",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_MarketVenus"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewCloseFactor.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewCloseFactor.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewCloseFactor"
+        "table_name": "Comptroller_event_NewCloseFactor"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewCloseFactor.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewCloseFactor.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewCloseFactor.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewCloseFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCloseFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCloseFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCloseFactor",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldCloseFactorMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCloseFactorMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_NewCloseFactor"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewCollateralFactor.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewCollateralFactor.json
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewCollateralFactor"
+        "table_name": "Comptroller_event_NewCollateralFactor"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewCollateralFactor.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewCollateralFactor.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewCollateralFactor.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewCollateralFactor.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract VToken",
+                    "name": "vToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCollateralFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCollateralFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCollateralFactor",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "vToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldCollateralFactorMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCollateralFactorMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_NewCollateralFactor"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewLiquidationIncentive.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewLiquidationIncentive.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewLiquidationIncentive.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewLiquidationIncentive.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewLiquidationIncentive",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldLiquidationIncentiveMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newLiquidationIncentiveMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_NewLiquidationIncentive"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewLiquidationIncentive.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewLiquidationIncentive.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewLiquidationIncentive"
+        "table_name": "Comptroller_event_NewLiquidationIncentive"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewMaxAssets.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewMaxAssets.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewMaxAssets.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewMaxAssets.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewMaxAssets"
+        "table_name": "Comptroller_event_NewMaxAssets"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewMaxAssets.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewMaxAssets.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldMaxAssets",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newMaxAssets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewMaxAssets",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldMaxAssets",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newMaxAssets",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_NewMaxAssets"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewPauseGuardian.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewPauseGuardian.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewPauseGuardian"
+        "table_name": "Comptroller_event_NewPauseGuardian"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewPauseGuardian.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewPauseGuardian.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPauseGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPauseGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPauseGuardian",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldPauseGuardian",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPauseGuardian",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_NewPauseGuardian"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewPauseGuardian.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewPauseGuardian.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewPriceOracle.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewPriceOracle.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract PriceOracle",
+                    "name": "oldPriceOracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract PriceOracle",
+                    "name": "newPriceOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPriceOracle",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldPriceOracle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPriceOracle",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_NewPriceOracle"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewPriceOracle.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewPriceOracle.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewPriceOracle.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewPriceOracle.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewPriceOracle"
+        "table_name": "Comptroller_event_NewPriceOracle"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIController.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIController.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract VAIControllerInterface",
+                    "name": "oldVAIController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract VAIControllerInterface",
+                    "name": "newVAIController",
+                    "type": "address"
+                }
+            ],
+            "name": "NewVAIController",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldVAIController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newVAIController",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_NewVAIController"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIController.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIController.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIController.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIController.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewVAIController"
+        "table_name": "Comptroller_event_NewVAIController"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIMintRate.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIMintRate.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewVAIMintRate"
+        "table_name": "Comptroller_event_NewVAIMintRate"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIMintRate.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIMintRate.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIMintRate.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewVAIMintRate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldVAIMintRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newVAIMintRate",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewVAIMintRate",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldVAIMintRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newVAIMintRate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_NewVAIMintRate"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewVenusRate.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewVenusRate.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewVenusRate"
+        "table_name": "Comptroller_event_NewVenusRate"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewVenusRate.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewVenusRate.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_NewVenusRate.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_NewVenusRate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldVenusRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newVenusRate",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewVenusRate",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldVenusRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newVenusRate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_NewVenusRate"
+    }
+}

--- a/parse/table_definitions_bsc/venus/Comptroller_event_VenusSpeedUpdated.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_VenusSpeedUpdated.json
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_VenusSpeedUpdated"
+        "table_name": "Comptroller_event_VenusSpeedUpdated"
     }
 }

--- a/parse/table_definitions_bsc/venus/Comptroller_event_VenusSpeedUpdated.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_VenusSpeedUpdated.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "venus",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_bsc/venus/Comptroller_event_VenusSpeedUpdated.json
+++ b/parse/table_definitions_bsc/venus/Comptroller_event_VenusSpeedUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract VToken",
+                    "name": "vToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "VenusSpeedUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xf6c14d4dfe45c132822ce28c646753c54994e59c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "vToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_VenusSpeedUpdated"
+    }
+}


### PR DESCRIPTION
#### What?
Adds all 19 events from the Venus Comptroller to blockchain-etl.

#### How? 
Generated via https://nansen-contract-parser-prod.web.app/ on address 0xf6C14D4DFE45C132822Ce28c646753C54994E59C on BSC chain.
