### PR TITLE
Arbitrum Nova - Sushiswap misc events

### DIFF
--- a/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Approval.json
+++ b/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+  "parser": {
+    "type": "log",
+    "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+    "abi": {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    "field_mapping": {}
+  },
+  "table": {
+    "dataset_name": "sushiswap",
+    "table_name": "UniswapV2Pair_event_Approval",
+    "table_description": "",
+    "schema": [
+      {
+        "name": "owner",
+        "description": "",
+        "type": "STRING"
+      },
+      {
+        "name": "spender",
+        "description": "",
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "",
+        "type": "STRING"
+      }
+    ]
+  }
+}

--- a/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Burn.json
+++ b/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+  "parser": {
+    "type": "log",
+    "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+    "abi": {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount0",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount1",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        }
+      ],
+      "name": "Burn",
+      "type": "event"
+    },
+    "field_mapping": {}
+  },
+  "table": {
+    "dataset_name": "sushiswap",
+    "table_name": "UniswapV2Pair_event_Burn",
+    "table_description": "",
+    "schema": [
+      {
+        "name": "sender",
+        "description": "",
+        "type": "STRING"
+      },
+      {
+        "name": "amount0",
+        "description": "",
+        "type": "STRING"
+      },
+      {
+        "name": "amount1",
+        "description": "",
+        "type": "STRING"
+      },
+      {
+        "name": "to",
+        "description": "",
+        "type": "STRING"
+      }
+    ]
+  }
+}

--- a/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Mint.json
+++ b/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+  "parser": {
+    "type": "log",
+    "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+    "abi": {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount0",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount1",
+          "type": "uint256"
+        }
+      ],
+      "name": "Mint",
+      "type": "event"
+    },
+    "field_mapping": {}
+  },
+  "table": {
+    "dataset_name": "sushiswap",
+    "table_name": "UniswapV2Pair_event_Mint",
+    "table_description": "",
+    "schema": [
+      {
+        "name": "sender",
+        "description": "",
+        "type": "STRING"
+      },
+      {
+        "name": "amount0",
+        "description": "",
+        "type": "STRING"
+      },
+      {
+        "name": "amount1",
+        "description": "",
+        "type": "STRING"
+      }
+    ]
+  }
+}

--- a/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Swap.json
+++ b/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Swap.json
@@ -1,0 +1,87 @@
+{
+  "parser": {
+    "abi": {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount0In",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount1In",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount0Out",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount1Out",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        }
+      ],
+      "name": "Swap",
+      "type": "event"
+    },
+    "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+    "field_mapping": {},
+    "type": "log"
+  },
+  "table": {
+    "dataset_name": "sushiswap",
+    "schema": [
+      {
+        "description": "",
+        "name": "sender",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "amount0In",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "amount1In",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "amount0Out",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "amount1Out",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "to",
+        "type": "STRING"
+      }
+    ],
+    "table_description": "",
+    "table_name": "UniswapV2Pair_event_Swap"
+  }
+}

--- a/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Sync.json
+++ b/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+  "parser": {
+    "type": "log",
+    "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+    "abi": {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint112",
+          "name": "reserve0",
+          "type": "uint112"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint112",
+          "name": "reserve1",
+          "type": "uint112"
+        }
+      ],
+      "name": "Sync",
+      "type": "event"
+    },
+    "field_mapping": {}
+  },
+  "table": {
+    "dataset_name": "sushiswap",
+    "table_name": "UniswapV2Pair_event_Sync",
+    "table_description": "",
+    "schema": [
+      {
+        "name": "reserve0",
+        "description": "",
+        "type": "STRING"
+      },
+      {
+        "name": "reserve1",
+        "description": "",
+        "type": "STRING"
+      }
+    ]
+  }
+}

--- a/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Transfer.json
+++ b/parse/table_definitions_arbitrum_nova/sushiswap/UniswapV2Pair_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+  "parser": {
+    "abi": {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+    "field_mapping": {},
+    "type": "log"
+  },
+  "table": {
+    "dataset_name": "sushiswap",
+    "schema": [
+      {
+        "description": "",
+        "name": "from",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "to",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "value",
+        "type": "STRING"
+      }
+    ],
+    "table_description": "",
+    "table_name": "UniswapV2Pair_event_Transfer"
+  }
+}


### PR DESCRIPTION
## What?
Arbitrum Nova - Sushiswap misc events. 

The table this PR depends on has been built successfully.

## Related PRs (optional)
https://github.com/nansen-ai/evmchain-etl-table-definitions/pull/103

