### PR TITLE
Add support for Liquidator events on Synthetix on Optimism

### DIFF
--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountFlaggedForLiquidation.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountFlaggedForLiquidation.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "Synthetix_event_",
+        "dataset_name": "synthetix",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "Liquidator_event_AccountFlaggedForLiquidation"
+        "table_name": "Synthetix_event_AccountFlaggedForLiquidation"
     }
 }

--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountFlaggedForLiquidation.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountFlaggedForLiquidation.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "deadline",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccountFlaggedForLiquidation",
+            "type": "event"
+        },
+        "contract_address": "0x61c7bc9b335e083c30c8a81b93575c361cde93e2",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "Synthetix_event_",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "deadline",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Liquidator_event_AccountFlaggedForLiquidation"
+    }
+}

--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountRemovedFromLiquidation.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountRemovedFromLiquidation.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "Synthetix_event_",
+        "dataset_name": "synthetix",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "Liquidator_event_AccountRemovedFromLiquidation"
+        "table_name": "Synthetix_event_AccountRemovedFromLiquidation"
     }
 }

--- a/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountRemovedFromLiquidation.json
+++ b/parse/table_definitions_optimism/synthetix/Synthetix_event_AccountRemovedFromLiquidation.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "time",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccountRemovedFromLiquidation",
+            "type": "event"
+        },
+        "contract_address": "0x61c7bc9b335e083c30c8a81b93575c361cde93e2",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "Synthetix_event_",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "time",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Liquidator_event_AccountRemovedFromLiquidation"
+    }
+}


### PR DESCRIPTION
## What?
Add support for Liquidator events  for Synthetix on Optimism

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions
OP Contract: [0x61C7BC9b335e083c30C8a81b93575c361cdE93E2](https://optimistic.etherscan.io/address/0x61C7BC9b335e083c30C8a81b93575c361cdE93E2)