### PR TITLE
Update contract addresses

### DIFF
--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Burn.json
@@ -43,7 +43,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Mint.json
@@ -55,7 +55,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/aave/StableDebtToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/aave/VariableDebtToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8', '0x513c7e3a9c69ca3e22550ef58ac1c0088e918fff', '0xc45a479877e1e9dfe9fcd4056c699575a1045daa', '0x8ffdf2de812095b1d19cb146e4c004587c0a0692', '0x8eb270e296023e9d92081fdf967ddd7878724424'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8', '0x513c7e3a9c69ca3e22550ef58ac1c0088e918fff', '0xc45a479877e1e9dfe9fcd4056c699575a1045daa', '0x8ffdf2de812095b1d19cb146e4c004587c0a0692', '0x8eb270e296023e9d92081fdf967ddd7878724424'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8', '0x513c7e3a9c69ca3e22550ef58ac1c0088e918fff', '0xc45a479877e1e9dfe9fcd4056c699575a1045daa', '0x8ffdf2de812095b1d19cb146e4c004587c0a0692', '0x8eb270e296023e9d92081fdf967ddd7878724424'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8', '0x513c7e3a9c69ca3e22550ef58ac1c0088e918fff', '0xc45a479877e1e9dfe9fcd4056c699575a1045daa', '0x8ffdf2de812095b1d19cb146e4c004587c0a0692', '0x8eb270e296023e9d92081fdf967ddd7878724424'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8', '0x513c7e3a9c69ca3e22550ef58ac1c0088e918fff', '0xc45a479877e1e9dfe9fcd4056c699575a1045daa', '0x8ffdf2de812095b1d19cb146e4c004587c0a0692', '0x8eb270e296023e9d92081fdf967ddd7878724424'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8', '0x513c7e3a9c69ca3e22550ef58ac1c0088e918fff', '0xc45a479877e1e9dfe9fcd4056c699575a1045daa', '0x8ffdf2de812095b1d19cb146e4c004587c0a0692', '0x8eb270e296023e9d92081fdf967ddd7878724424'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_avalanche/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Burn.json
@@ -43,7 +43,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Mint.json
@@ -55,7 +55,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_avalanche/aave/StableDebtToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907', '0xce186f6cccb0c955445bb9d10c59cae488fea559', '0xa8669021776bc142dfca87c21b4a52595bcbb40a'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907', '0xce186f6cccb0c955445bb9d10c59cae488fea559', '0xa8669021776bc142dfca87c21b4a52595bcbb40a'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907', '0xce186f6cccb0c955445bb9d10c59cae488fea559', '0xa8669021776bc142dfca87c21b4a52595bcbb40a'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907', '0xce186f6cccb0c955445bb9d10c59cae488fea559', '0xa8669021776bc142dfca87c21b4a52595bcbb40a'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907', '0xce186f6cccb0c955445bb9d10c59cae488fea559', '0xa8669021776bc142dfca87c21b4a52595bcbb40a'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_avalanche/aave/VariableDebtToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907', '0xce186f6cccb0c955445bb9d10c59cae488fea559', '0xa8669021776bc142dfca87c21b4a52595bcbb40a'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8', '0x513c7e3a9c69ca3e22550ef58ac1c0088e918fff', '0xc45a479877e1e9dfe9fcd4056c699575a1045daa'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "0xa5ba6e5ec19a1bf23c857991c857db62b2aa187b",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "0xa5ba6e5ec19a1bf23c857991c857db62b2aa187b",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "0xa5ba6e5ec19a1bf23c857991c857db62b2aa187b",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "0xa5ba6e5ec19a1bf23c857991c857db62b2aa187b",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_fantom/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "0xa5ba6e5ec19a1bf23c857991c857db62b2aa187b",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Burn.json
@@ -43,7 +43,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Mint.json
@@ -55,7 +55,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_fantom/aave/StableDebtToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6', '0x08cb71192985e936c7cd166a8b268035e400c3c3', '0x78246294a4c6fbf614ed73ccc9f8b875ca8ee841'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x77ca01483f379e58174739308945f044e1a764dc', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x77ca01483f379e58174739308945f044e1a764dc', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x77ca01483f379e58174739308945f044e1a764dc', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_fantom/aave/VariableDebtToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351', '0x77ca01483f379e58174739308945f044e1a764dc', '0x34e2ed44ef7466d5f9e0b782b5c08b57475e7907'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Approval.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_BalanceTransfer.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_BalanceTransfer.json
@@ -31,7 +31,7 @@
             "name": "BalanceTransfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Burn.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Initialized.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Initialized.json
@@ -55,7 +55,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Mint.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xf329e36c7bf6e5e86ce2150875a84ce77f477375', '0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee', '0x6ab707aca953edaefbc4fd23ba73294241490620', '0x191c10aa4af7c30e871e70c95db0e4eb77237530', '0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', '0x625e7708f30ca75bfd92586e17077590c60eb4cd', '0x078f358208685046a11c85e8ad32895ded33a249', '0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8'])",
+        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/AToken_v3_event_Transfer.json
+++ b/parse/table_definitions_optimism/aave/AToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT aToken from ('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "contract_address": "SELECT aToken FROM REF('PoolConfigurator_event_ReserveInitialized') group by aToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Burn.json
@@ -43,7 +43,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Mint.json
@@ -55,7 +55,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_optimism/aave/StableDebtToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xfaef6a702d15428e588d4c0614aefb4348d83d48', '0xd94112b5b62d53c9402e7a60289c6810def1dc9b', '0x70effc565db6eef7b927610155602d31b670e802', '0x89d976629b7055ff1ca02b927ba3e020f22a44e4', '0xf15f26710c827dde8acba678682f3ce24f2fb56e', '0x307ffe186f84a3bc2613d1ea417a5737d69a7007', '0x633b207dd676331c413d4c013a6294b0fe47cd0e', '0xd8ad37849950903571df17049516a5cd4cbe55f6'])",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Approval.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Burn.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Initialized.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Mint.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Transfer.json
+++ b/parse/table_definitions_optimism/aave/VariableDebtToken_v3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
## What?
Updating contract addresses to be a dynamic query so if markets are added to the PoolConfigurator, we wouldn't need to update the currently hardcoded contract addresses. Note that Fantom was missing a bunch of markets before this

## How? 
Used the following query parametrized for each of the 12 contract types to verify that we're at parity with existing hardcoded addresses:
```
WITH 
old_ver as(
SELECT * FROM UNNEST(['0xe80761ea617f66f96274ea5e8c37f03960ecc679', '0x8619d80fb0141ba7f184cbf22fd724116d9f7ffc', '0xfb00ac187a8eb5afae4eace434f493eb62672df7', '0x953a573793604af8d41f306feb8274190db4ae0e', '0x4a1c3ad6ed28a636ee1751c69071f6be75deb8b8', '0xfccf3cabbe80101232d343252614b6a3ee81c989', '0x92b42c66840c7ad907b4bf74879ff3ef7c529473', '0x0c84331e39d6658cd6e6b9ba04736cc4c4734351'])
),
new_ver as (
    SELECT variableDebtToken FROM `blockchain-etl.arbitrum_aave.PoolConfigurator_event_ReserveInitialized` GROUP BY variableDebtToken
)
(SELECT * from old_ver except distinct select * from new_ver)
union all
(SELECT * from new_ver except distinct select * from old_ver)
```

## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
