### PR TITLE
Add Seaport table definitions

### DIFF
--- a/parse/table_definitions_arbitrum/seaport/SeaportV14_event_CounterIncremented.json
+++ b/parse/table_definitions_arbitrum/seaport/SeaportV14_event_CounterIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "CounterIncremented",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_CounterIncremented",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "newCounter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/SeaportV14_event_OrderCancelled.json
+++ b/parse/table_definitions_arbitrum/seaport/SeaportV14_event_OrderCancelled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/SeaportV14_event_OrderFulfilled.json
+++ b/parse/table_definitions_arbitrum/seaport/SeaportV14_event_OrderFulfilled.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enumItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structSpentItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enumItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "addresspayable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structReceivedItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "OrderFulfilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderFulfilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "consideration",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/SeaportV14_event_OrderValidated.json
+++ b/parse/table_definitions_arbitrum/seaport/SeaportV14_event_OrderValidated.json
@@ -1,0 +1,159 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "zone",
+                            "type": "address"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enumItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "structOfferItem[]",
+                            "name": "offer",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enumItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "addresspayable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "structConsiderationItem[]",
+                            "name": "consideration",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "enumOrderType",
+                            "name": "orderType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "zoneHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalOriginalConsiderationItems",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structOrderParameters",
+                    "name": "orderParameters",
+                    "type": "tuple"
+                }
+            ],
+            "name": "OrderValidated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderValidated",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "orderParameters",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_arbitrum/seaport/SeaportV14_event_OrdersMatched.json
+++ b/parse/table_definitions_arbitrum/seaport/SeaportV14_event_OrdersMatched.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32[]",
+                    "name": "orderHashes",
+                    "type": "bytes32[]"
+                }
+            ],
+            "name": "OrdersMatched",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrdersMatched",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHashes",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/seaport/SeaportV11_event_CounterIncremented.json
+++ b/parse/table_definitions_avalanche/seaport/SeaportV11_event_CounterIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "CounterIncremented",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_CounterIncremented",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "newCounter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/seaport/SeaportV11_event_OrderCancelled.json
+++ b/parse/table_definitions_avalanche/seaport/SeaportV11_event_OrderCancelled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/seaport/SeaportV11_event_OrderFulfilled.json
+++ b/parse/table_definitions_avalanche/seaport/SeaportV11_event_OrderFulfilled.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct SpentItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct ReceivedItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "OrderFulfilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_OrderFulfilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "consideration",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/seaport/SeaportV11_event_OrderValidated.json
+++ b/parse/table_definitions_avalanche/seaport/SeaportV11_event_OrderValidated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderValidated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_OrderValidated",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/seaport/SeaportV14_event_CounterIncremented.json
+++ b/parse/table_definitions_avalanche/seaport/SeaportV14_event_CounterIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "CounterIncremented",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_CounterIncremented",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "newCounter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/seaport/SeaportV14_event_OrderCancelled.json
+++ b/parse/table_definitions_avalanche/seaport/SeaportV14_event_OrderCancelled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/seaport/SeaportV14_event_OrderFulfilled.json
+++ b/parse/table_definitions_avalanche/seaport/SeaportV14_event_OrderFulfilled.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enumItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structSpentItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enumItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "addresspayable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structReceivedItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "OrderFulfilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderFulfilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "consideration",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/seaport/SeaportV14_event_OrderValidated.json
+++ b/parse/table_definitions_avalanche/seaport/SeaportV14_event_OrderValidated.json
@@ -1,0 +1,159 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "zone",
+                            "type": "address"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enumItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "structOfferItem[]",
+                            "name": "offer",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enumItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "addresspayable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "structConsiderationItem[]",
+                            "name": "consideration",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "enumOrderType",
+                            "name": "orderType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "zoneHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalOriginalConsiderationItems",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structOrderParameters",
+                    "name": "orderParameters",
+                    "type": "tuple"
+                }
+            ],
+            "name": "OrderValidated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderValidated",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "orderParameters",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_avalanche/seaport/SeaportV14_event_OrdersMatched.json
+++ b/parse/table_definitions_avalanche/seaport/SeaportV14_event_OrdersMatched.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32[]",
+                    "name": "orderHashes",
+                    "type": "bytes32[]"
+                }
+            ],
+            "name": "OrdersMatched",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrdersMatched",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHashes",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/seaport/SeaportV11_event_CounterIncremented.json
+++ b/parse/table_definitions_bsc/seaport/SeaportV11_event_CounterIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "CounterIncremented",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_CounterIncremented",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "newCounter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/seaport/SeaportV11_event_OrderCancelled.json
+++ b/parse/table_definitions_bsc/seaport/SeaportV11_event_OrderCancelled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/seaport/SeaportV11_event_OrderFulfilled.json
+++ b/parse/table_definitions_bsc/seaport/SeaportV11_event_OrderFulfilled.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct SpentItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct ReceivedItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "OrderFulfilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_OrderFulfilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "consideration",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/seaport/SeaportV11_event_OrderValidated.json
+++ b/parse/table_definitions_bsc/seaport/SeaportV11_event_OrderValidated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderValidated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_OrderValidated",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/seaport/SeaportV14_event_CounterIncremented.json
+++ b/parse/table_definitions_bsc/seaport/SeaportV14_event_CounterIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "CounterIncremented",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_CounterIncremented",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "newCounter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/seaport/SeaportV14_event_OrderCancelled.json
+++ b/parse/table_definitions_bsc/seaport/SeaportV14_event_OrderCancelled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/seaport/SeaportV14_event_OrderFulfilled.json
+++ b/parse/table_definitions_bsc/seaport/SeaportV14_event_OrderFulfilled.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enumItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structSpentItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enumItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "addresspayable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structReceivedItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "OrderFulfilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderFulfilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "consideration",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/seaport/SeaportV14_event_OrderValidated.json
+++ b/parse/table_definitions_bsc/seaport/SeaportV14_event_OrderValidated.json
@@ -1,0 +1,159 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "zone",
+                            "type": "address"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enumItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "structOfferItem[]",
+                            "name": "offer",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enumItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "addresspayable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "structConsiderationItem[]",
+                            "name": "consideration",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "enumOrderType",
+                            "name": "orderType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "zoneHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalOriginalConsiderationItems",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structOrderParameters",
+                    "name": "orderParameters",
+                    "type": "tuple"
+                }
+            ],
+            "name": "OrderValidated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderValidated",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "orderParameters",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_bsc/seaport/SeaportV14_event_OrdersMatched.json
+++ b/parse/table_definitions_bsc/seaport/SeaportV14_event_OrdersMatched.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32[]",
+                    "name": "orderHashes",
+                    "type": "bytes32[]"
+                }
+            ],
+            "name": "OrdersMatched",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrdersMatched",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHashes",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_optimism/seaport/SeaportV11_event_CounterIncremented.json
+++ b/parse/table_definitions_optimism/seaport/SeaportV11_event_CounterIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "CounterIncremented",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_CounterIncremented",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "newCounter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_optimism/seaport/SeaportV11_event_OrderCancelled.json
+++ b/parse/table_definitions_optimism/seaport/SeaportV11_event_OrderCancelled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_optimism/seaport/SeaportV11_event_OrderFulfilled.json
+++ b/parse/table_definitions_optimism/seaport/SeaportV11_event_OrderFulfilled.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct SpentItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct ReceivedItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "OrderFulfilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_OrderFulfilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "consideration",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_optimism/seaport/SeaportV11_event_OrderValidated.json
+++ b/parse/table_definitions_optimism/seaport/SeaportV11_event_OrderValidated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000006c3852cbef3e08e8df289169ede581",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderValidated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV11_event_OrderValidated",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_optimism/seaport/SeaportV14_event_CounterIncremented.json
+++ b/parse/table_definitions_optimism/seaport/SeaportV14_event_CounterIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "CounterIncremented",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_CounterIncremented",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "newCounter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_optimism/seaport/SeaportV14_event_OrderCancelled.json
+++ b/parse/table_definitions_optimism/seaport/SeaportV14_event_OrderCancelled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_optimism/seaport/SeaportV14_event_OrderFulfilled.json
+++ b/parse/table_definitions_optimism/seaport/SeaportV14_event_OrderFulfilled.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enumItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structSpentItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enumItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "addresspayable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structReceivedItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "OrderFulfilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderFulfilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offerer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "zone",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "recipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "offer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "consideration",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_optimism/seaport/SeaportV14_event_OrderValidated.json
+++ b/parse/table_definitions_optimism/seaport/SeaportV14_event_OrderValidated.json
@@ -1,0 +1,159 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "zone",
+                            "type": "address"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enumItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "structOfferItem[]",
+                            "name": "offer",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enumItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifierOrCriteria",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endAmount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "addresspayable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "structConsiderationItem[]",
+                            "name": "consideration",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "enumOrderType",
+                            "name": "orderType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "zoneHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalOriginalConsiderationItems",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "structOrderParameters",
+                    "name": "orderParameters",
+                    "type": "tuple"
+                }
+            ],
+            "name": "OrderValidated",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrderValidated",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "orderParameters",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/parse/table_definitions_optimism/seaport/SeaportV14_event_OrdersMatched.json
+++ b/parse/table_definitions_optimism/seaport/SeaportV14_event_OrdersMatched.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32[]",
+                    "name": "orderHashes",
+                    "type": "bytes32[]"
+                }
+            ],
+            "name": "OrdersMatched",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "table_name": "SeaportV14_event_OrdersMatched",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHashes",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## What?
Add the new Seaport contract, currently at V1.4

For Avalanche, BNB and Optimism also add the V1.1 events, as we did not have them yet.

## How? 
I used cli tools to build the table defenitions

