### PR TITLE
Add table definition for ThenaPairFactory_event_PairCreated

### DIFF
--- a/parse/table_definitions_bsc/thena/ThenaPairFactory_event_PairCreated.json
+++ b/parse/table_definitions_bsc/thena/ThenaPairFactory_event_PairCreated.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token0",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token1",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "stable",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "pair",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "noname",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PairCreated",
+            "type": "event"
+        },
+        "contract_address": "0xafd89d21bdb66d00817d4153e055830b1c2b3970",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "thena",
+        "schema": [
+            {
+                "description": "",
+                "name": "token0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stable",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pair",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "noname",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ThenaPairFactory_event_PairCreated"
+    }
+}


### PR DESCRIPTION
## What?
ie: Add support for thena contract events 

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) or cli tools to build the table defenitions
Sourced the event information from https://bscscan.com/address/0x3d3F41D3Faaa4F3e91F9dc65A2790F809e045bB7
## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
The contract: https://bscscan.com/address/0xafd89d21bdb66d00817d4153e055830b1c2b3970#readProxyContract seems to be a ProxyContract therefore I wasn't able to build up the tables def from the ABI parser so I did it manually, using the Velodrome one and the information at the PairEvent from BSCscan
