### PR TITLE
rm arbitrum aave/usd duplicate in chainlink

### DIFF
--- a/parse/table_definitions_arbitrum/chainlink/view_AccessControlledOffchainAggregator_info.sql
+++ b/parse/table_definitions_arbitrum/chainlink/view_AccessControlledOffchainAggregator_info.sql
@@ -4,7 +4,6 @@ STRUCT('0x2946220288dbbf77df0030fcecc2a8348cbbe32c' as contract_address, 8 as de
 STRUCT('0xb20bd22d3d2e5a628523d37b3ded569598eb649b' as contract_address, 8 as decimals, '0xd0c7101eacbb49f3decccc166d238410d6d46d57' as proxy_address, 'WBTC / USD' as description, 4 as version),
 STRUCT('0x3607e46698d218b3a5cae44bf381475c0a5e2ca7' as contract_address, 8 as decimals, '0x639fe6ab55c921f74e7fac1ee960c0b6293ba612' as proxy_address, 'ETH / USD' as description, 4 as version),
 STRUCT('0x3c6abda21358c15601a3175d8dd66d0c572cc904' as contract_address, 8 as decimals, '0xad1d5344aade45f43e596773bcc4c423eabdd034' as proxy_address, 'AAVE / USD' as description, 4 as version),
-STRUCT('0x3c6abda21358c15601a3175d8dd66d0c572cc904' as contract_address, 8 as decimals, '0xad1d5344aade45f43e596773bcc4c423eabdd034' as proxy_address, 'AAVE / USD' as description, 4 as version),
 STRUCT('0x9b8ddcf800a7bfcdebad6d65514de59160a2c9cc' as contract_address, 8 as decimals, '0x86e53cf1b870786351da77a57575e79cb55812cb' as proxy_address, 'LINK / USD' as description, 4 as version),
 STRUCT('0x0e9b5c79e005a30bf3fbb4d8cccb6b0082ac5a17' as contract_address, 18 as decimals, '0xb523ae262d20a936bc152e6023996e46fdc2a95d' as proxy_address, 'WSTETH / ETH' as description, 4 as version),
 STRUCT('0x20cd97619a51d1a6f1910ce62d98aceb9a13d5e6' as contract_address, 8 as decimals, '0x0411d28c94d85a36bc72cb0f875dfa8371d8ffff' as proxy_address, 'LUSD / USD' as description, 4 as version),


### PR DESCRIPTION
## What?
My [previous PR](https://github.com/nansen-ai/evmchain-etl-table-definitions/pull/147/files) has a duplicate entry for Arbitrum 'AAVE / USD' chainlink.

This PR removes the duplicate.

## How? 
N/A

## Related PRs (optional)
See above.

## Anything Else?
None.