### PR TITLE
Add Perennial events for Arbitrum market

### DIFF
--- a/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Approval.json
+++ b/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x1960628db367281b1a186dd5b80b5dd6978f016f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArbitrumEcosystemVault_event_Approval"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Claim.json
+++ b/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Claim.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "assets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Claim",
+            "type": "event"
+        },
+        "contract_address": "0x1960628db367281b1a186dd5b80b5dd6978f016f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "assets",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArbitrumEcosystemVault_event_Claim"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_CollateralUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_CollateralUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "targetCollateral",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CollateralUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x1960628db367281b1a186dd5b80b5dd6978f016f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "targetCollateral",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArbitrumEcosystemVault_event_CollateralUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Deposit.json
+++ b/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Deposit.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "assets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "contract_address": "0x1960628db367281b1a186dd5b80b5dd6978f016f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "assets",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArbitrumEcosystemVault_event_Deposit"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0x1960628db367281b1a186dd5b80b5dd6978f016f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArbitrumEcosystemVault_event_Initialized"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_PositionUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_PositionUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "targetPosition",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PositionUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x1960628db367281b1a186dd5b80b5dd6978f016f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "targetPosition",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArbitrumEcosystemVault_event_PositionUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Redemption.json
+++ b/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Redemption.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "shares",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redemption",
+            "type": "event"
+        },
+        "contract_address": "0x1960628db367281b1a186dd5b80b5dd6978f016f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "shares",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArbitrumEcosystemVault_event_Redemption"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/perennial/ArbitrumEcosystemVault_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x1960628db367281b1a186dd5b80b5dd6978f016f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArbitrumEcosystemVault_event_Transfer"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Approval.json
+++ b/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x5a572b5fbbc43387b5ef8de2c4728a4108ef24a6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlueChipVault_event_Approval"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Claim.json
+++ b/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Claim.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "assets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Claim",
+            "type": "event"
+        },
+        "contract_address": "0x5a572b5fbbc43387b5ef8de2c4728a4108ef24a6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "assets",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlueChipVault_event_Claim"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_CollateralUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_CollateralUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "targetCollateral",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CollateralUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x5a572b5fbbc43387b5ef8de2c4728a4108ef24a6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "targetCollateral",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlueChipVault_event_CollateralUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Deposit.json
+++ b/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Deposit.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "assets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "contract_address": "0x5a572b5fbbc43387b5ef8de2c4728a4108ef24a6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "assets",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlueChipVault_event_Deposit"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0x5a572b5fbbc43387b5ef8de2c4728a4108ef24a6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlueChipVault_event_Initialized"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_PositionUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_PositionUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "targetPosition",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PositionUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x5a572b5fbbc43387b5ef8de2c4728a4108ef24a6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "targetPosition",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlueChipVault_event_PositionUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Redemption.json
+++ b/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Redemption.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "shares",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redemption",
+            "type": "event"
+        },
+        "contract_address": "0x5a572b5fbbc43387b5ef8de2c4728a4108ef24a6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "shares",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlueChipVault_event_Redemption"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/perennial/BlueChipVault_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x5a572b5fbbc43387b5ef8de2c4728a4108ef24a6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlueChipVault_event_Transfer"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Collateral_event_AccountSettle.json
+++ b/parse/table_definitions_arbitrum/perennial/Collateral_event_AccountSettle.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "Fixed18",
+                    "name": "amount",
+                    "type": "int256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newShortfall",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccountSettle",
+            "type": "event"
+        },
+        "contract_address": "0xaf8ced28fce00abd30463d55da81156aa5aeeec2",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newShortfall",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Collateral_event_AccountSettle"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Collateral_event_Deposit.json
+++ b/parse/table_definitions_arbitrum/perennial/Collateral_event_Deposit.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "contract_address": "0xaf8ced28fce00abd30463d55da81156aa5aeeec2",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Collateral_event_Deposit"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Collateral_event_FeeClaim.json
+++ b/parse/table_definitions_arbitrum/perennial/Collateral_event_FeeClaim.json
@@ -4,16 +4,22 @@
             "anonymous": false,
             "inputs": [
                 {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
                     "indexed": false,
                     "internalType": "UFixed18",
-                    "name": "newMinCollateral",
+                    "name": "amount",
                     "type": "uint256"
                 }
             ],
-            "name": "MinCollateralUpdated",
+            "name": "FeeClaim",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
+        "contract_address": "0xaf8ced28fce00abd30463d55da81156aa5aeeec2",
         "field_mapping": {},
         "type": "log"
     },
@@ -22,11 +28,16 @@
         "schema": [
             {
                 "description": "",
-                "name": "newMinCollateral",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Controller_event_MinCollateralUpdated"
+        "table_name": "Collateral_event_FeeClaim"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/Collateral_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/Collateral_event_Initialized.json
@@ -5,15 +5,15 @@
             "inputs": [
                 {
                     "indexed": false,
-                    "internalType": "bool",
-                    "name": "newPaused",
-                    "type": "bool"
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
                 }
             ],
-            "name": "PausedUpdated",
+            "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
+        "contract_address": "0xaf8ced28fce00abd30463d55da81156aa5aeeec2",
         "field_mapping": {},
         "type": "log"
     },
@@ -22,11 +22,11 @@
         "schema": [
             {
                 "description": "",
-                "name": "newPaused",
+                "name": "version",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Controller_event_PausedUpdated"
+        "table_name": "Collateral_event_Initialized"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/Collateral_event_Liquidation.json
+++ b/parse/table_definitions_arbitrum/perennial/Collateral_event_Liquidation.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "fee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Liquidation",
+            "type": "event"
+        },
+        "contract_address": "0xaf8ced28fce00abd30463d55da81156aa5aeeec2",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Collateral_event_Liquidation"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Collateral_event_ProductSettle.json
+++ b/parse/table_definitions_arbitrum/perennial/Collateral_event_ProductSettle.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "protocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "productFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProductSettle",
+            "type": "event"
+        },
+        "contract_address": "0xaf8ced28fce00abd30463d55da81156aa5aeeec2",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "protocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "productFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Collateral_event_ProductSettle"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Collateral_event_ShortfallResolution.json
+++ b/parse/table_definitions_arbitrum/perennial/Collateral_event_ShortfallResolution.json
@@ -5,21 +5,21 @@
             "inputs": [
                 {
                     "indexed": true,
-                    "internalType": "uint256",
-                    "name": "coordinatorId",
-                    "type": "uint256"
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
                 },
                 {
                     "indexed": false,
-                    "internalType": "address",
-                    "name": "newOwner",
-                    "type": "address"
+                    "internalType": "UFixed18",
+                    "name": "amount",
+                    "type": "uint256"
                 }
             ],
-            "name": "CoordinatorOwnerUpdated",
+            "name": "ShortfallResolution",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
+        "contract_address": "0xaf8ced28fce00abd30463d55da81156aa5aeeec2",
         "field_mapping": {},
         "type": "log"
     },
@@ -28,16 +28,16 @@
         "schema": [
             {
                 "description": "",
-                "name": "coordinatorId",
+                "name": "product",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "newOwner",
+                "name": "amount",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Controller_event_CoordinatorOwnerUpdated"
+        "table_name": "Collateral_event_ShortfallResolution"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/Collateral_event_Withdrawal.json
+++ b/parse/table_definitions_arbitrum/perennial/Collateral_event_Withdrawal.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdrawal",
+            "type": "event"
+        },
+        "contract_address": "0xaf8ced28fce00abd30463d55da81156aa5aeeec2",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Collateral_event_Withdrawal"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_CollateralUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_CollateralUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract ICollateral",
+                    "name": "newCollateral",
+                    "type": "address"
+                }
+            ],
+            "name": "CollateralUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newCollateral",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_CollateralUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_CollateralUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_CollateralUpdated.json
@@ -13,7 +13,7 @@
             "name": "CollateralUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorCreated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorCreated.json
@@ -19,7 +19,7 @@
             "name": "CoordinatorCreated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorCreated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorCreated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "coordinatorId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "CoordinatorCreated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "coordinatorId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_CoordinatorCreated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorOwnerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorOwnerUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "coordinatorId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "CoordinatorOwnerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "coordinatorId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_CoordinatorOwnerUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorPendingOwnerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorPendingOwnerUpdated.json
@@ -19,7 +19,7 @@
             "name": "CoordinatorPendingOwnerUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorPendingOwnerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorPendingOwnerUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "coordinatorId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPendingOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "CoordinatorPendingOwnerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "coordinatorId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPendingOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_CoordinatorPendingOwnerUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorTreasuryUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorTreasuryUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "coordinatorId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newTreasury",
+                    "type": "address"
+                }
+            ],
+            "name": "CoordinatorTreasuryUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "coordinatorId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTreasury",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_CoordinatorTreasuryUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorTreasuryUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_CoordinatorTreasuryUpdated.json
@@ -19,7 +19,7 @@
             "name": "CoordinatorTreasuryUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_IncentivizationFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_IncentivizationFeeUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newIncentivizationFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "IncentivizationFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newIncentivizationFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_IncentivizationFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_IncentivizationFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_IncentivizationFeeUpdated.json
@@ -13,7 +13,7 @@
             "name": "IncentivizationFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_IncentivizerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_IncentivizerUpdated.json
@@ -13,7 +13,7 @@
             "name": "IncentivizerUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_IncentivizerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_IncentivizerUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract IIncentivizer",
+                    "name": "newIncentivizer",
+                    "type": "address"
+                }
+            ],
+            "name": "IncentivizerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newIncentivizer",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_IncentivizerUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_Initialized.json
@@ -13,7 +13,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_Initialized"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_LiquidationFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_LiquidationFeeUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newLiquidationFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidationFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newLiquidationFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_LiquidationFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_LiquidationFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_LiquidationFeeUpdated.json
@@ -13,7 +13,7 @@
             "name": "LiquidationFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_MinCollateralUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_MinCollateralUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newMinCollateral",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MinCollateralUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newMinCollateral",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_MinCollateralUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_MinFundingFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_MinFundingFeeUpdated.json
@@ -13,7 +13,7 @@
             "name": "MinFundingFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_MinFundingFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_MinFundingFeeUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newMinFundingFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MinFundingFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newMinFundingFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_MinFundingFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_MultiInvokerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_MultiInvokerUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract IMultiInvoker",
+                    "name": "newMultiInvoker",
+                    "type": "address"
+                }
+            ],
+            "name": "MultiInvokerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newMultiInvoker",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_MultiInvokerUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_MultiInvokerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_MultiInvokerUpdated.json
@@ -13,7 +13,7 @@
             "name": "MultiInvokerUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_PausedUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_PausedUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "newPaused",
+                    "type": "bool"
+                }
+            ],
+            "name": "PausedUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newPaused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_PausedUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_PauserUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_PauserUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPauser",
+                    "type": "address"
+                }
+            ],
+            "name": "PauserUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newPauser",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_PauserUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_PauserUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_PauserUpdated.json
@@ -13,7 +13,7 @@
             "name": "PauserUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_ProductBeaconUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_ProductBeaconUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract IBeacon",
+                    "name": "newProductBeacon",
+                    "type": "address"
+                }
+            ],
+            "name": "ProductBeaconUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newProductBeacon",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Controller_event_ProductBeaconUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Controller_event_ProductBeaconUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Controller_event_ProductBeaconUpdated.json
@@ -13,7 +13,7 @@
             "name": "ProductBeaconUpdated",
             "type": "event"
         },
-        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b,
+        "contract_address": "0xa59ef0208418559770a48d7ae4f260a28763167b",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Incentivizer_event_Claim.json
+++ b/parse/table_definitions_arbitrum/perennial/Incentivizer_event_Claim.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "programId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Claim",
+            "type": "event"
+        },
+        "contract_address": "0xfc20bcca96bde758e9c69151d99cecfeae3ab37e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "programId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Incentivizer_event_Claim"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Incentivizer_event_FeeClaim.json
+++ b/parse/table_definitions_arbitrum/perennial/Incentivizer_event_FeeClaim.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "Token18",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FeeClaim",
+            "type": "event"
+        },
+        "contract_address": "0xfc20bcca96bde758e9c69151d99cecfeae3ab37e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Incentivizer_event_FeeClaim"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Incentivizer_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/Incentivizer_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0xfc20bcca96bde758e9c69151d99cecfeae3ab37e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Incentivizer_event_Initialized"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Incentivizer_event_ProgramComplete.json
+++ b/parse/table_definitions_arbitrum/perennial/Incentivizer_event_ProgramComplete.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "programId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProgramComplete",
+            "type": "event"
+        },
+        "contract_address": "0xfc20bcca96bde758e9c69151d99cecfeae3ab37e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "programId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Incentivizer_event_ProgramComplete"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Incentivizer_event_ProgramCreated.json
+++ b/parse/table_definitions_arbitrum/perennial/Incentivizer_event_ProgramCreated.json
@@ -1,0 +1,143 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "programId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "coordinatorId",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "UFixed18",
+                                    "name": "maker",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed18",
+                                    "name": "taker",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Position",
+                            "name": "amount",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "start",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "duration",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Token18",
+                            "name": "token",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct ProgramInfo",
+                    "name": "programInfo",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "programFeeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProgramCreated",
+            "type": "event"
+        },
+        "contract_address": "0xfc20bcca96bde758e9c69151d99cecfeae3ab37e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "programId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "coordinatorId",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "maker",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "taker",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "amount",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "name": "start",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "duration",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "token",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "programInfo",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "programFeeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Incentivizer_event_ProgramCreated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Incentivizer_event_ProgramStarted.json
+++ b/parse/table_definitions_arbitrum/perennial/Incentivizer_event_ProgramStarted.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IProduct",
+                    "name": "product",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "programId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProgramStarted",
+            "type": "event"
+        },
+        "contract_address": "0xfc20bcca96bde758e9c69151d99cecfeae3ab37e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "product",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "programId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Incentivizer_event_ProgramStarted"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/ProductBeacon_event_OwnershipTransferred.json
+++ b/parse/table_definitions_arbitrum/perennial/ProductBeacon_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xc12b0fe62441baad525cd7d770cf21c883c77bc6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ProductBeacon_event_OwnershipTransferred"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/ProductBeacon_event_Upgraded.json
+++ b/parse/table_definitions_arbitrum/perennial/ProductBeacon_event_Upgraded.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "Upgraded",
+            "type": "event"
+        },
+        "contract_address": "0xc12b0fe62441baad525cd7d770cf21c883c77bc6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ProductBeacon_event_Upgraded"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_AccountSettle.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_AccountSettle.json
@@ -25,7 +25,7 @@
             "name": "AccountSettle",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_AccountSettle.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_AccountSettle.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "preVersion",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "toVersion",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccountSettle",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "preVersion",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toVersion",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_AccountSettle"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_ClosedUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_ClosedUpdated.json
@@ -19,7 +19,7 @@
             "name": "ClosedUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_ClosedUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_ClosedUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bool",
+                    "name": "newClosed",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ClosedUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newClosed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_ClosedUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_FundingFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_FundingFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "FundingFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_FundingFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_FundingFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newFundingFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FundingFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newFundingFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_FundingFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_Initialized.json
@@ -13,7 +13,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_Initialized"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_JumpRateUtilizationCurveUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_JumpRateUtilizationCurveUpdated.json
@@ -72,7 +72,7 @@
                         "type": "STRING"
                     }
                 ],
-                "name": "",
+                "name": "updates",
                 "type": "RECORD"
             },
             {

--- a/parse/table_definitions_arbitrum/perennial/Product_event_JumpRateUtilizationCurveUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_JumpRateUtilizationCurveUpdated.json
@@ -41,7 +41,7 @@
             "name": "JumpRateUtilizationCurveUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_JumpRateUtilizationCurveUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_JumpRateUtilizationCurveUpdated.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "PackedFixed18",
+                            "name": "minRate",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "PackedFixed18",
+                            "name": "maxRate",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "PackedFixed18",
+                            "name": "targetRate",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "PackedUFixed18",
+                            "name": "targetUtilization",
+                            "type": "uint128"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct JumpRateUtilizationCurve",
+                    "name": "",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "JumpRateUtilizationCurveUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "minRate",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "maxRate",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "targetRate",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "targetUtilization",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_JumpRateUtilizationCurveUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_JumpRateUtilizationCurveUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_JumpRateUtilizationCurveUpdated.json
@@ -28,7 +28,7 @@
                     ],
                     "indexed": false,
                     "internalType": "struct JumpRateUtilizationCurve",
-                    "name": "",
+                    "name": "updates",
                     "type": "tuple"
                 },
                 {

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MaintenanceUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MaintenanceUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newMaintenance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MaintenanceUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newMaintenance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_MaintenanceUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MaintenanceUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MaintenanceUpdated.json
@@ -19,7 +19,7 @@
             "name": "MaintenanceUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MakeClosed.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MakeClosed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MakeClosed",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_MakeClosed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MakeClosed.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MakeClosed.json
@@ -25,7 +25,7 @@
             "name": "MakeClosed",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MakeOpened.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MakeOpened.json
@@ -25,7 +25,7 @@
             "name": "MakeOpened",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MakeOpened.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MakeOpened.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MakeOpened",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_MakeOpened"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MakerFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MakerFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "MakerFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MakerFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MakerFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newMakerFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MakerFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newMakerFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_MakerFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MakerLimitUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MakerLimitUpdated.json
@@ -19,7 +19,7 @@
             "name": "MakerLimitUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_MakerLimitUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_MakerLimitUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newMakerLimit",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MakerLimitUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newMakerLimit",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_MakerLimitUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_OracleUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_OracleUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oracleVersion",
+                    "type": "uint256"
+                }
+            ],
+            "name": "OracleUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOracle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracleVersion",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_OracleUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_OracleUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_OracleUpdated.json
@@ -19,7 +19,7 @@
             "name": "OracleUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_PendingMakerFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_PendingMakerFeeUpdated.json
@@ -13,7 +13,7 @@
             "name": "PendingMakerFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_PendingMakerFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_PendingMakerFeeUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newMakerFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PendingMakerFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newMakerFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_PendingMakerFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_PendingPositionFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_PendingPositionFeeUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newPositionFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PendingPositionFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newPositionFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_PendingPositionFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_PendingPositionFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_PendingPositionFeeUpdated.json
@@ -13,7 +13,7 @@
             "name": "PendingPositionFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_PendingTakerFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_PendingTakerFeeUpdated.json
@@ -13,7 +13,7 @@
             "name": "PendingTakerFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_PendingTakerFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_PendingTakerFeeUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newTakerFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PendingTakerFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newTakerFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_PendingTakerFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_PositionFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_PositionFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newPositionFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PositionFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newPositionFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_PositionFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_PositionFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_PositionFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "PositionFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_Settle.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_Settle.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "preVersion",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "toVersion",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Settle",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "preVersion",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toVersion",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_Settle"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_Settle.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_Settle.json
@@ -19,7 +19,7 @@
             "name": "Settle",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_TakeClosed.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_TakeClosed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TakeClosed",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_TakeClosed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_TakeClosed.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_TakeClosed.json
@@ -25,7 +25,7 @@
             "name": "TakeClosed",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_TakeOpened.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_TakeOpened.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TakeOpened",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_TakeOpened"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_TakeOpened.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_TakeOpened.json
@@ -25,7 +25,7 @@
             "name": "TakeOpened",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Product_event_TakerFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_TakerFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "UFixed18",
+                    "name": "newTakerFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TakerFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newTakerFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Product_event_TakerFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Product_event_TakerFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Product_event_TakerFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "TakerFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x427bc8694ea59f063b7caa43e3dd77d416922250",
+        "contract_address": "SELECT * FROM UNNEST(['0x260422c091da8c88ef21f5d1112ab43aa94787cd', '0x5b99d122af97ba012aa237bd01577278bfaaff1e', '0x5e660b7b8357059241eaec143e1e68a5a108d035', '0x4e67a8a428206af5a6ac00ba08a67ce827182985'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/ProxyAdmin_event_OwnershipTransferred.json
+++ b/parse/table_definitions_arbitrum/perennial/ProxyAdmin_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x4f75cfbfc8b4a109659471b8d4593f5b19be169b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ProxyAdmin_event_OwnershipTransferred"
+    }
+}


### PR DESCRIPTION
## What?
Adds support for Perennial finance events https://docs.perennial.finance/developers/deployed-contracts
## How? 
Used the Nansen contract parsers. I also combined the events for 4 markets that share the same implementation contract into 1 set of Product events

## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
