### PR TITLE
Add PythOracle events on Arbitrum

### DIFF
--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_AdminChanged.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_AdminChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "previousAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "AdminChanged",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousAdmin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newAdmin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_AdminChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_BatchPriceFeedUpdate.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_BatchPriceFeedUpdate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "chainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "sequenceNumber",
+                    "type": "uint64"
+                }
+            ],
+            "name": "BatchPriceFeedUpdate",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "chainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sequenceNumber",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_BatchPriceFeedUpdate"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_BeaconUpgraded.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_BeaconUpgraded.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "beacon",
+                    "type": "address"
+                }
+            ],
+            "name": "BeaconUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "beacon",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_BeaconUpgraded"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_ContractUpgraded.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_ContractUpgraded.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldImplementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ContractUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldImplementation",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newImplementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_ContractUpgraded"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_DataSourcesSet.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_DataSourcesSet.json
@@ -1,0 +1,67 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource[]",
+                    "name": "oldDataSources",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource[]",
+                    "name": "newDataSources",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "DataSourcesSet",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldDataSources",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newDataSources",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_DataSourcesSet"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_FeeSet.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_FeeSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FeeSet",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_FeeSet"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_GovernanceDataSourceSet.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_GovernanceDataSourceSet.json
@@ -1,0 +1,102 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource",
+                    "name": "oldDataSource",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource",
+                    "name": "newDataSource",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "initialSequence",
+                    "type": "uint64"
+                }
+            ],
+            "name": "GovernanceDataSourceSet",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "chainId",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "emitterAddress",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "oldDataSource",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "chainId",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "emitterAddress",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newDataSource",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "initialSequence",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_GovernanceDataSourceSet"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "version",
+                    "type": "uint8"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_Initialized"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_OwnershipTransferred.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_OwnershipTransferred"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_PriceFeedUpdate.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_PriceFeedUpdate.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "publishTime",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int64",
+                    "name": "price",
+                    "type": "int64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "conf",
+                    "type": "uint64"
+                }
+            ],
+            "name": "PriceFeedUpdate",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "publishTime",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "price",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "conf",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_PriceFeedUpdate"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_Upgraded.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_Upgraded.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "Upgraded",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_Upgraded"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_ValidPeriodSet.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_ValidPeriodSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldValidPeriod",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newValidPeriod",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ValidPeriodSet",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldValidPeriod",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newValidPeriod",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_ValidPeriodSet"
+    }
+}

--- a/parse/table_definitions_arbitrum/pyth/PythOracle_event_WormholeAddressSet.json
+++ b/parse/table_definitions_arbitrum/pyth/PythOracle_event_WormholeAddressSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldWormholeAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newWormholeAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "WormholeAddressSet",
+            "type": "event"
+        },
+        "contract_address": "0xff1a0f4744e8582df1ae09d5611b887b6a12925c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldWormholeAddress",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newWormholeAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_WormholeAddressSet"
+    }
+}


### PR DESCRIPTION
## What?
ie: Add support for uniswap contract events 

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) or cli tools to build the table definitions

## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
