### PR TITLE
Added Arbitrum Curve 2pool TokenExchange

### DIFF
--- a/parse/table_definitions_arbitrum/curve/2pool_event_TokenExchange.json
+++ b/parse/table_definitions_arbitrum/curve/2pool_event_TokenExchange.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "buyer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sold_id",
+                    "type": "int128"
+                },
+                {
+                    "indexed": false,
+                    "name": "tokens_sold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "bought_id",
+                    "type": "int128"
+                },
+                {
+                    "indexed": false,
+                    "name": "tokens_bought",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TokenExchange",
+            "type": "event"
+        },
+        "contract_address": "0x7f90122bf0700f9e7e1f688fe926940e8839f353",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "buyer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sold_id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokens_sold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bought_id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokens_bought",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "2pool_event_TokenExchange"
+    }
+}


### PR DESCRIPTION
## What?
Added support for TokenExchange events on the Arbitrum Curve 2pool

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions