### PR TITLE
add parsed events for stargate finance bridge on arbitrum

### DIFF
--- a/parse/table_definitions_arbitrum/stargate_finance/Bridge_event_OwnershipTransferred.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Bridge_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x352d8275aae3e0c2404d9f68f6cee084b5beb3dd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Bridge_event_OwnershipTransferred"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Bridge_event_SendMsg.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Bridge_event_SendMsg.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "msgType",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "nonce",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SendMsg",
+            "type": "event"
+        },
+        "contract_address": "0x352d8275aae3e0c2404d9f68f6cee084b5beb3dd",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "msgType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "nonce",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Bridge_event_SendMsg"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Approval.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xd22363e3762ca7339569f3d33eade20127d5f98c', '0xdecc0c09c3b5f6e92ef4184125d5648a66e35298', '0x165137624f1f692e69659f944bf69de02874ee27', '0x368605d9c6243a80903b9e326f1cddde088b8924', '0x2f8bc9081c7fcfec25b9f41a50d97eaa592058ae', '0x3533f5e279bdbf550272a199a223da798d9eff78', '0x5421fa1a48f9ff81e4580557e86c7c0d24c18036'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_Approval"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Burn.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Burn.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountLP",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountLP",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_Burn"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_ChainPathUpdate.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_ChainPathUpdate.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "dstChainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "dstPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "weight",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ChainPathUpdate",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "dstChainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dstPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "weight",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_ChainPathUpdate"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_CreditChainPath.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_CreditChainPath.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "chainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "srcPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "idealBalance",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CreditChainPath",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "chainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "idealBalance",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_CreditChainPath"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_DeltaParamUpdated.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_DeltaParamUpdated.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "batched",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "swapDeltaBP",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "lpDeltaBP",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "defaultSwapMode",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "defaultLPMode",
+                    "type": "bool"
+                }
+            ],
+            "name": "DeltaParamUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "batched",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "swapDeltaBP",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "lpDeltaBP",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "defaultSwapMode",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "defaultLPMode",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_DeltaParamUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_FeeLibraryUpdated.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_FeeLibraryUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "feeLibraryAddr",
+                    "type": "address"
+                }
+            ],
+            "name": "FeeLibraryUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "feeLibraryAddr",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_FeeLibraryUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_FeesUpdated.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_FeesUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "mintFeeBP",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FeesUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "mintFeeBP",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_FeesUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_InstantRedeemLocal.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_InstantRedeemLocal.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountLP",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "InstantRedeemLocal",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountLP",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_InstantRedeemLocal"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Mint.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Mint.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountLP",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "mintFeeAmountSD",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountLP",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mintFeeAmountSD",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_Mint"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_RedeemLocal.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_RedeemLocal.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountLP",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "chainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "dstPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "to",
+                    "type": "bytes"
+                }
+            ],
+            "name": "RedeemLocal",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountLP",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "chainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dstPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_RedeemLocal"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_RedeemLocalCallback.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_RedeemLocalCallback.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "_to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_amountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_amountToMintSD",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RedeemLocalCallback",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "_to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amountToMintSD",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_RedeemLocalCallback"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_RedeemRemote.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_RedeemRemote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "chainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "dstPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountLP",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RedeemRemote",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "chainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dstPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountLP",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_RedeemRemote"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_SendCredits.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_SendCredits.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "dstChainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "dstPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "credits",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "idealBalance",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SendCredits",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "dstChainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dstPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "credits",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "idealBalance",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_SendCredits"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_StopSwapUpdated.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_StopSwapUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "swapStop",
+                    "type": "bool"
+                }
+            ],
+            "name": "StopSwapUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "swapStop",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_StopSwapUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Swap.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Swap.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "chainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "dstPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "eqReward",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "eqFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "protocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "lpFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Swap",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "chainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dstPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "eqReward",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "eqFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "protocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "lpFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_Swap"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_SwapRemote.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_SwapRemote.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "protocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "dstFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SwapRemote",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "protocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dstFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_SwapRemote"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_Transfer"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_WithdrawMintFeeBalance.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_WithdrawMintFeeBalance.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawMintFeeBalance",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_WithdrawMintFeeBalance"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_WithdrawProtocolFeeBalance.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_WithdrawProtocolFeeBalance.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawProtocolFeeBalance",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_WithdrawProtocolFeeBalance"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Pool_event_WithdrawRemote.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Pool_event_WithdrawRemote.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "srcChainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "srcPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "swapAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "mintAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawRemote",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x915a55e36a01285a14f05de6e81ed9ce89772f8e', '0x892785f33cdee22a30aef750f285e18c18040c3e', '0xb6cfcf89a7b22988bfc96632ac2a9d6dab60d641', '0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c', '0xf39b7be294cb36de8c510e267b82bb588705d977', '0x600e576f9d853c95d58029093a16ee49646f3ca5'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "srcChainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "swapAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mintAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_event_WithdrawRemote"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Router_event_CachedSwapSaved.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Router_event_CachedSwapSaved.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "chainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "srcAddress",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountLD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "payload",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "reason",
+                    "type": "bytes"
+                }
+            ],
+            "name": "CachedSwapSaved",
+            "type": "event"
+        },
+        "contract_address": "0x53bf833a5d6c4dda888f69c22c88c9f356a41614",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "chainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAddress",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "nonce",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountLD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "payload",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reason",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Router_event_CachedSwapSaved"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Router_event_OwnershipTransferred.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Router_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x53bf833a5d6c4dda888f69c22c88c9f356a41614",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Router_event_OwnershipTransferred"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Router_event_RedeemLocalCallback.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Router_event_RedeemLocalCallback.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "srcChainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes",
+                    "name": "srcAddress",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "srcPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "dstPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "mintAmountSD",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RedeemLocalCallback",
+            "type": "event"
+        },
+        "contract_address": "0x53bf833a5d6c4dda888f69c22c88c9f356a41614",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "srcChainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAddress",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "nonce",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dstPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mintAmountSD",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Router_event_RedeemLocalCallback"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Router_event_Revert.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Router_event_Revert.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "bridgeFunctionType",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "chainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "srcAddress",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Revert",
+            "type": "event"
+        },
+        "contract_address": "0x53bf833a5d6c4dda888f69c22c88c9f356a41614",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "bridgeFunctionType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "chainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAddress",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "nonce",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Router_event_Revert"
+    }
+}

--- a/parse/table_definitions_arbitrum/stargate_finance/Router_event_RevertRedeemLocal.json
+++ b/parse/table_definitions_arbitrum/stargate_finance/Router_event_RevertRedeemLocal.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "srcChainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_srcPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_dstPoolId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "to",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "redeemAmountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "mintAmountSD",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes",
+                    "name": "srcAddress",
+                    "type": "bytes"
+                }
+            ],
+            "name": "RevertRedeemLocal",
+            "type": "event"
+        },
+        "contract_address": "0x53bf833a5d6c4dda888f69c22c88c9f356a41614",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stargate_finance",
+        "schema": [
+            {
+                "description": "",
+                "name": "srcChainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_srcPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_dstPoolId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "redeemAmountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mintAmountSD",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "nonce",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Router_event_RevertRedeemLocal"
+    }
+}


### PR DESCRIPTION
## What?
Add support for stargate finance bridge contract events 

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) and [these](https://stargateprotocol.gitbook.io/stargate/developers/contract-addresses/mainnet#arbitrum) addresses
