### PR TITLE
Arbitrum Perennial - update market event contract_address

### DIFF
--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_AccountPositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_AccountPositionProcessed.json
@@ -65,7 +65,7 @@
             "name": "AccountPositionProcessed",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_BeneficiaryUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_BeneficiaryUpdated.json
@@ -13,7 +13,7 @@
             "name": "BeneficiaryUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_CoordinatorUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_CoordinatorUpdated.json
@@ -13,7 +13,7 @@
             "name": "CoordinatorUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_FeeClaimed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_FeeClaimed.json
@@ -19,7 +19,7 @@
             "name": "FeeClaimed",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_Initialized.json
@@ -13,7 +13,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_ParameterUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_ParameterUpdated.json
@@ -85,7 +85,7 @@
             "name": "ParameterUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_PositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_PositionProcessed.json
@@ -119,7 +119,7 @@
             "name": "PositionProcessed",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_RewardClaimed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_RewardClaimed.json
@@ -19,7 +19,7 @@
             "name": "RewardClaimed",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_RewardUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_RewardUpdated.json
@@ -13,7 +13,7 @@
             "name": "RewardUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_RiskParameterUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_RiskParameterUpdated.json
@@ -144,7 +144,7 @@
             "name": "RiskParameterUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_Updated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_Updated.json
@@ -55,7 +55,7 @@
             "name": "Updated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x90a664846960aafa2c164605aebb8e9ac338f9a0', '0xcc83e3cda48547e3c250a88c8d5e97089fd28f60', '0x02258be4ac91982dc1af7a3d2c4f05be6079c253', '0x7e34b5cbc6427bd53ecfaefc9ac2cad04e982f78'])",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
## What?
ie: Fetches contract address from `MarketFactory_v2_event_MarketCreated`

## How? 
ie: I referenced `MarketFactory_v2_event_MarketCreated` to get contract addresses for new markets

## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
