### PR TITLE
Perennial v2 signed integers for position fees

### DIFF
--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_AccountPositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_AccountPositionProcessed.json
@@ -48,7 +48,7 @@
                         {
                             "internalType": "UFixed6",
                             "name": "positionFee",
-                            "type": "uint256"
+                            "type": "int256"
                         },
                         {
                             "internalType": "UFixed6",

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_PositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_PositionProcessed.json
@@ -32,7 +32,7 @@
                         {
                             "internalType": "UFixed6",
                             "name": "positionFeeMaker",
-                            "type": "uint256"
+                            "type": "int256"
                         },
                         {
                             "internalType": "UFixed6",


### PR DESCRIPTION
## What?
ie: Add support for signed integers on position fees for perennial v2

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) or cli tools to build the table definitions.

![image](https://github.com/nansen-ai/evmchain-etl-table-definitions/assets/120756425/97d40e1a-d802-47f4-94da-4bca9ae1188f)


## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
