### PR TITLE
Separate table definitions for perennial v2.1

### DIFF
--- a/parse/table_definitions_arbitrum/perennial/Market_v2_1_event_AccountPositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_1_event_AccountPositionProcessed.json
@@ -1,0 +1,131 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "fromOracleVersion",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "toOracleVersion",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "fromPosition",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "toPosition",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "Fixed6",
+                            "name": "collateralAmount",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "rewardAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "positionFee",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "keeper",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LocalAccumulationResult",
+                    "name": "accumulationResult",
+                    "type": "tuple"
+                }
+            ],
+            "name": "AccountPositionProcessed",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fromOracleVersion",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toOracleVersion",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fromPosition",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toPosition",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "collateralAmount",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "rewardAmount",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "keeper",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "accumulationResult",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_event_AccountPositionProcessed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_1_event_AccountPositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_1_event_AccountPositionProcessed.json
@@ -126,6 +126,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_event_AccountPositionProcessed"
+        "table_name": "Market_v2_1_event_AccountPositionProcessed"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_1_event_PositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_1_event_PositionProcessed.json
@@ -235,6 +235,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_event_PositionProcessed"
+        "table_name": "Market_v2_1_event_PositionProcessed"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_1_event_PositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_1_event_PositionProcessed.json
@@ -1,0 +1,240 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "fromOracleVersion",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "toOracleVersion",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "fromPosition",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "toPosition",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "UFixed6",
+                            "name": "positionFeeMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "positionFeeFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "fundingMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "fundingLong",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "fundingShort",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "fundingFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "interestMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "interestLong",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "interestShort",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "interestFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "pnlMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "pnlLong",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "pnlShort",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "rewardMaker",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "rewardLong",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "rewardShort",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct VersionAccumulationResult",
+                    "name": "accumulationResult",
+                    "type": "tuple"
+                }
+            ],
+            "name": "PositionProcessed",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromOracleVersion",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toOracleVersion",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fromPosition",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toPosition",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "positionFeeMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFeeFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingShort",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestShort",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pnlMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pnlLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pnlShort",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "rewardMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "rewardLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "rewardShort",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "accumulationResult",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_event_PositionProcessed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_AccountPositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_AccountPositionProcessed.json
@@ -48,7 +48,7 @@
                         {
                             "internalType": "UFixed6",
                             "name": "positionFee",
-                            "type": "int256"
+                            "type": "uint256"
                         },
                         {
                             "internalType": "UFixed6",

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_event_PositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_event_PositionProcessed.json
@@ -32,7 +32,7 @@
                         {
                             "internalType": "UFixed6",
                             "name": "positionFeeMaker",
-                            "type": "int256"
+                            "type": "uint256"
                         },
                         {
                             "internalType": "UFixed6",


### PR DESCRIPTION
## What?
ie: Add support for perennial 2.1 account position processed and position processed events 

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) or cli tools to build the table definitions