### PR TITLE
Add marketplace events for Paintswap

### DIFF
--- a/parse/table_definitions_fantom/paintswap/MarketplaceV2_event_Sold.json
+++ b/parse/table_definitions_fantom/paintswap/MarketplaceV2_event_Sold.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "marketplaceId",
+                    "type": "uint256"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "address[]",
+                    "name": "nfts",
+                    "type": "address[]"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "tokenIds",
+                    "type": "uint256[]"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "amountBatches",
+                    "type": "uint256[]"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "price",
+                    "type": "uint128"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "buyer",
+                    "type": "address"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "seller",
+                    "type": "address"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                  }
+            ],
+            "name": "Sold",
+            "type": "event"
+        },
+        "contract_address": "0xf3df7b6dccc267393784a3876d0cbcbdc73147d4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paintswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "marketplaceId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "nfts",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenIds",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountBatches",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "price",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "buyer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "seller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MarketplaceV2_event_Sold"
+    }
+}

--- a/parse/table_definitions_fantom/paintswap/MarketplaceV3_event_Sold.json
+++ b/parse/table_definitions_fantom/paintswap/MarketplaceV3_event_Sold.json
@@ -1,0 +1,120 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "marketplaceId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address[]",
+                    "name": "nfts",
+                    "type": "address[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "tokenIds",
+                    "type": "uint256[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "amountBatches",
+                    "type": "uint256[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "price",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "buyer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "seller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "offerId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Sold",
+            "type": "event"
+        },
+        "contract_address": "0xf3df7b6dccc267393784a3876d0cbcbdc73147d4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paintswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "marketplaceId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "nfts",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenIds",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountBatches",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "price",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "buyer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "seller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "offerId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MarketplaceV3_event_Sold"
+    }
+}


### PR DESCRIPTION
Adds the `Sold` event for both v2 and v3 marketplace. The only difference in the abi seem to be the addition of 1 field (`offerId`) in v3. This should provide all information on actual NFTs sold. Counts check out when referenced against https://paintswap.finance/marketplace/fantom/stats/global.