### PR TITLE
[Gauntlet] interestRateCalculator query fix

### DIFF
--- a/parse/table_definitions_arbitrum/synonym/PiecewiseInterestRate_event_ModelSet.json
+++ b/parse/table_definitions_arbitrum/synonym/PiecewiseInterestRate_event_ModelSet.json
@@ -30,7 +30,7 @@
             "name": "ModelSet",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT interest_rate_calculator FROM ref('AssetRegistry_event_AssetRegistered')",
+        "contract_address": "SELECT interestRateCalculator FROM ref('AssetRegistry_event_AssetRegistered') group by interestRateCalculator",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/synonym/PiecewiseInterestRate_event_OwnershipTransferred.json
+++ b/parse/table_definitions_arbitrum/synonym/PiecewiseInterestRate_event_OwnershipTransferred.json
@@ -19,7 +19,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT interest_rate_calculator FROM ref('AssetRegistry_event_AssetRegistered')",
+        "contract_address": "SELECT interestRateCalculator FROM ref('AssetRegistry_event_AssetRegistered') group by interestRateCalculator",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
## What?
Corrects column name in contract_address call and removes distinct in favor of group by

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/)

## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
