### PR TITLE
Perennial v2.2 tables

### DIFF
--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Initialized.json
@@ -5,15 +5,15 @@
             "inputs": [
                 {
                     "indexed": false,
-                    "internalType": "contract IOracleProvider",
-                    "name": "newOracle",
-                    "type": "address"
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
                 }
             ],
-            "name": "OracleUpdated",
+            "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
         "field_mapping": {},
         "type": "log"
     },
@@ -22,11 +22,11 @@
         "schema": [
             {
                 "description": "",
-                "name": "newOracle",
+                "name": "version",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_OracleUpdated"
+        "table_name": "MarketFactory_v2_2_event_Initialized"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_InstanceRegistered.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_InstanceRegistered.json
@@ -4,16 +4,16 @@
             "anonymous": false,
             "inputs": [
                 {
-                    "indexed": false,
-                    "internalType": "contract IOracleProvider",
-                    "name": "newOracle",
+                    "indexed": true,
+                    "internalType": "contract IInstance",
+                    "name": "instance",
                     "type": "address"
                 }
             ],
-            "name": "OracleUpdated",
+            "name": "InstanceRegistered",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
         "field_mapping": {},
         "type": "log"
     },
@@ -22,11 +22,11 @@
         "schema": [
             {
                 "description": "",
-                "name": "newOracle",
+                "name": "instance",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_OracleUpdated"
+        "table_name": "MarketFactory_v2_2_event_InstanceRegistered"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_MarketCreated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_MarketCreated.json
@@ -1,0 +1,67 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IMarket",
+                    "name": "market",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "Token18",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract IOracleProvider",
+                            "name": "oracle",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct IMarket.MarketDefinition",
+                    "name": "definition",
+                    "type": "tuple"
+                }
+            ],
+            "name": "MarketCreated",
+            "type": "event"
+        },
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "market",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "token",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "oracle",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "definition",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MarketFactory_v2_2_event_MarketCreated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_OperatorUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_OperatorUpdated.json
@@ -10,16 +10,22 @@
                     "type": "address"
                 },
                 {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
                     "indexed": false,
-                    "internalType": "Fixed6",
-                    "name": "amount",
-                    "type": "int256"
+                    "internalType": "bool",
+                    "name": "newEnabled",
+                    "type": "bool"
                 }
             ],
-            "name": "ExposureClaimed",
+            "name": "OperatorUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
         "field_mapping": {},
         "type": "log"
     },
@@ -33,11 +39,16 @@
             },
             {
                 "description": "",
-                "name": "amount",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newEnabled",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_ExposureClaimed"
+        "table_name": "MarketFactory_v2_2_event_OperatorUpdated"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_OwnerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_OwnerUpdated.json
@@ -4,16 +4,16 @@
             "anonymous": false,
             "inputs": [
                 {
-                    "indexed": false,
-                    "internalType": "contract IOracleProvider",
-                    "name": "newOracle",
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
                     "type": "address"
                 }
             ],
-            "name": "OracleUpdated",
+            "name": "OwnerUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
         "field_mapping": {},
         "type": "log"
     },
@@ -22,11 +22,11 @@
         "schema": [
             {
                 "description": "",
-                "name": "newOracle",
+                "name": "newOwner",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_OracleUpdated"
+        "table_name": "MarketFactory_v2_2_event_OwnerUpdated"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_ParameterUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_ParameterUpdated.json
@@ -7,67 +7,47 @@
                     "components": [
                         {
                             "internalType": "UFixed6",
-                            "name": "fundingFee",
+                            "name": "protocolFee",
                             "type": "uint256"
                         },
                         {
                             "internalType": "UFixed6",
-                            "name": "interestFee",
+                            "name": "maxFee",
                             "type": "uint256"
                         },
                         {
                             "internalType": "UFixed6",
-                            "name": "positionFee",
+                            "name": "maxFeeAbsolute",
                             "type": "uint256"
                         },
                         {
                             "internalType": "UFixed6",
-                            "name": "oracleFee",
+                            "name": "maxCut",
                             "type": "uint256"
                         },
                         {
                             "internalType": "UFixed6",
-                            "name": "riskFee",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "maxPendingGlobal",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "maxPendingLocal",
+                            "name": "maxRate",
                             "type": "uint256"
                         },
                         {
                             "internalType": "UFixed6",
-                            "name": "settlementFee",
+                            "name": "minMaintenance",
                             "type": "uint256"
                         },
                         {
-                            "internalType": "bool",
-                            "name": "takerCloseAlways",
-                            "type": "bool"
+                            "internalType": "UFixed6",
+                            "name": "minEfficiency",
+                            "type": "uint256"
                         },
                         {
-                            "internalType": "bool",
-                            "name": "makerCloseAlways",
-                            "type": "bool"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "closed",
-                            "type": "bool"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "settle",
-                            "type": "bool"
+                            "internalType": "UFixed6",
+                            "name": "referralFee",
+                            "type": "uint256"
                         }
                     ],
                     "indexed": false,
-                    "internalType": "struct MarketParameter",
+                    "internalType": "struct ProtocolParameter",
                     "name": "newParameter",
                     "type": "tuple"
                 }
@@ -75,7 +55,7 @@
             "name": "ParameterUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
         "field_mapping": {},
         "type": "log"
     },
@@ -87,62 +67,42 @@
                 "fields": [
                     {
                         "description": "",
-                        "name": "fundingFee",
+                        "name": "protocolFee",
                         "type": "STRING"
                     },
                     {
                         "description": "",
-                        "name": "interestFee",
+                        "name": "maxFee",
                         "type": "STRING"
                     },
                     {
                         "description": "",
-                        "name": "positionFee",
+                        "name": "maxFeeAbsolute",
                         "type": "STRING"
                     },
                     {
                         "description": "",
-                        "name": "oracleFee",
+                        "name": "maxCut",
                         "type": "STRING"
                     },
                     {
                         "description": "",
-                        "name": "riskFee",
+                        "name": "maxRate",
                         "type": "STRING"
                     },
                     {
                         "description": "",
-                        "name": "maxPendingGlobal",
+                        "name": "minMaintenance",
                         "type": "STRING"
                     },
                     {
                         "description": "",
-                        "name": "maxPendingLocal",
+                        "name": "minEfficiency",
                         "type": "STRING"
                     },
                     {
                         "description": "",
-                        "name": "settlementFee",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "takerCloseAlways",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "makerCloseAlways",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "closed",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "settle",
+                        "name": "referralFee",
                         "type": "STRING"
                     }
                 ],
@@ -151,6 +111,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_ParameterUpdated"
+        "table_name": "MarketFactory_v2_2_event_ParameterUpdated"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Paused.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Paused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [],
+        "table_description": "",
+        "table_name": "MarketFactory_v2_2_event_Paused"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_PauserUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_PauserUpdated.json
@@ -4,16 +4,16 @@
             "anonymous": false,
             "inputs": [
                 {
-                    "indexed": false,
-                    "internalType": "contract IOracleProvider",
-                    "name": "newOracle",
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newPauser",
                     "type": "address"
                 }
             ],
-            "name": "OracleUpdated",
+            "name": "PauserUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
         "field_mapping": {},
         "type": "log"
     },
@@ -22,11 +22,11 @@
         "schema": [
             {
                 "description": "",
-                "name": "newOracle",
+                "name": "newPauser",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_OracleUpdated"
+        "table_name": "MarketFactory_v2_2_event_PauserUpdated"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_PendingOwnerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_PendingOwnerUpdated.json
@@ -4,16 +4,16 @@
             "anonymous": false,
             "inputs": [
                 {
-                    "indexed": false,
-                    "internalType": "contract IOracleProvider",
-                    "name": "newOracle",
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newPendingOwner",
                     "type": "address"
                 }
             ],
-            "name": "OracleUpdated",
+            "name": "PendingOwnerUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
         "field_mapping": {},
         "type": "log"
     },
@@ -22,11 +22,11 @@
         "schema": [
             {
                 "description": "",
-                "name": "newOracle",
+                "name": "newPendingOwner",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_OracleUpdated"
+        "table_name": "MarketFactory_v2_2_event_PendingOwnerUpdated"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_ReferralFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_ReferralFeeUpdated.json
@@ -6,20 +6,20 @@
                 {
                     "indexed": true,
                     "internalType": "address",
-                    "name": "account",
+                    "name": "referrer",
                     "type": "address"
                 },
                 {
                     "indexed": false,
-                    "internalType": "Fixed6",
-                    "name": "amount",
-                    "type": "int256"
+                    "internalType": "UFixed6",
+                    "name": "newFee",
+                    "type": "uint256"
                 }
             ],
-            "name": "ExposureClaimed",
+            "name": "ReferralFeeUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
         "field_mapping": {},
         "type": "log"
     },
@@ -28,16 +28,16 @@
         "schema": [
             {
                 "description": "",
-                "name": "account",
+                "name": "referrer",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "amount",
+                "name": "newFee",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_ExposureClaimed"
+        "table_name": "MarketFactory_v2_2_event_ReferralFeeUpdated"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Unpaused.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Unpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [],
+        "table_description": "",
+        "table_name": "MarketFactory_v2_2_event_Unpaused"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_AccountPositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_AccountPositionProcessed.json
@@ -1,0 +1,263 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "timestamp",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "orders",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "collateral",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "protection",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerReferral",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerReferral",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct Order",
+                    "name": "order",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "Fixed6",
+                            "name": "collateral",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "linearFee",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "proportionalFee",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "adiabaticFee",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "settlementFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "liquidationFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "subtractiveFee",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CheckpointAccumulationResult",
+                    "name": "accumulationResult",
+                    "type": "tuple"
+                }
+            ],
+            "name": "AccountPositionProcessed",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "orderId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "timestamp",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "orders",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "collateral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "protection",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerReferral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerReferral",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "order",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "collateral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "linearFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "proportionalFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "adiabaticFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "settlementFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "subtractiveFee",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "accumulationResult",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_2_event_AccountPositionProcessed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_AccountPositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_AccountPositionProcessed.json
@@ -130,7 +130,7 @@
             "name": "AccountPositionProcessed",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_BeneficiaryUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_BeneficiaryUpdated.json
@@ -4,19 +4,13 @@
             "anonymous": false,
             "inputs": [
                 {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                },
-                {
                     "indexed": false,
-                    "internalType": "Fixed6",
-                    "name": "amount",
-                    "type": "int256"
+                    "internalType": "address",
+                    "name": "newBeneficiary",
+                    "type": "address"
                 }
             ],
-            "name": "ExposureClaimed",
+            "name": "BeneficiaryUpdated",
             "type": "event"
         },
         "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
@@ -28,16 +22,11 @@
         "schema": [
             {
                 "description": "",
-                "name": "account",
-                "type": "STRING"
-            },
-            {
-                "description": "",
-                "name": "amount",
+                "name": "newBeneficiary",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_ExposureClaimed"
+        "table_name": "Market_v2_2_event_BeneficiaryUpdated"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_CoordinatorUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_CoordinatorUpdated.json
@@ -4,19 +4,13 @@
             "anonymous": false,
             "inputs": [
                 {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                },
-                {
                     "indexed": false,
-                    "internalType": "Fixed6",
-                    "name": "amount",
-                    "type": "int256"
+                    "internalType": "address",
+                    "name": "newCoordinator",
+                    "type": "address"
                 }
             ],
-            "name": "ExposureClaimed",
+            "name": "CoordinatorUpdated",
             "type": "event"
         },
         "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
@@ -28,16 +22,11 @@
         "schema": [
             {
                 "description": "",
-                "name": "account",
-                "type": "STRING"
-            },
-            {
-                "description": "",
-                "name": "amount",
+                "name": "newCoordinator",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_ExposureClaimed"
+        "table_name": "Market_v2_2_event_CoordinatorUpdated"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_ExposureClaimed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_ExposureClaimed.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "Fixed6",
+                    "name": "amount",
+                    "type": "int256"
+                }
+            ],
+            "name": "ExposureClaimed",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_2_event_ExposureClaimed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_FeeClaimed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_FeeClaimed.json
@@ -11,12 +11,12 @@
                 },
                 {
                     "indexed": false,
-                    "internalType": "Fixed6",
+                    "internalType": "UFixed6",
                     "name": "amount",
-                    "type": "int256"
+                    "type": "uint256"
                 }
             ],
-            "name": "ExposureClaimed",
+            "name": "FeeClaimed",
             "type": "event"
         },
         "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_ExposureClaimed"
+        "table_name": "Market_v2_2_event_FeeClaimed"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_Initialized.json
@@ -4,19 +4,13 @@
             "anonymous": false,
             "inputs": [
                 {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                },
-                {
                     "indexed": false,
-                    "internalType": "Fixed6",
-                    "name": "amount",
-                    "type": "int256"
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
                 }
             ],
-            "name": "ExposureClaimed",
+            "name": "Initialized",
             "type": "event"
         },
         "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
@@ -28,16 +22,11 @@
         "schema": [
             {
                 "description": "",
-                "name": "account",
-                "type": "STRING"
-            },
-            {
-                "description": "",
-                "name": "amount",
+                "name": "version",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "Market_v2_2_event_ExposureClaimed"
+        "table_name": "Market_v2_2_event_Initialized"
     }
 }

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_OracleUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_OracleUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract IOracleProvider",
+                    "name": "newOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "OracleUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOracle",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_2_event_OracleUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_OrderCreated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_OrderCreated.json
@@ -1,0 +1,167 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "timestamp",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "orders",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "collateral",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "protection",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerReferral",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerReferral",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct Order",
+                    "name": "order",
+                    "type": "tuple"
+                }
+            ],
+            "name": "OrderCreated",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "timestamp",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "orders",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "collateral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "protection",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerReferral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerReferral",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "order",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_2_event_OrderCreated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_OrderCreated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_OrderCreated.json
@@ -81,7 +81,7 @@
             "name": "OrderCreated",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_ParameterUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_ParameterUpdated.json
@@ -1,0 +1,156 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "UFixed6",
+                            "name": "fundingFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "interestFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "positionFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "oracleFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "riskFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "maxPendingGlobal",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "maxPendingLocal",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "settlementFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "takerCloseAlways",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "makerCloseAlways",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "closed",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "settle",
+                            "type": "bool"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketParameter",
+                    "name": "newParameter",
+                    "type": "tuple"
+                }
+            ],
+            "name": "ParameterUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "fundingFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "oracleFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "riskFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "maxPendingGlobal",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "maxPendingLocal",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "settlementFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerCloseAlways",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerCloseAlways",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "closed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "settle",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newParameter",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_2_event_ParameterUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_PositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_PositionProcessed.json
@@ -194,7 +194,7 @@
             "name": "PositionProcessed",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_PositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_PositionProcessed.json
@@ -1,0 +1,392 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "timestamp",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "orders",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "collateral",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "protection",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerReferral",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerReferral",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct Order",
+                    "name": "order",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "UFixed6",
+                            "name": "positionFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "positionFeeMaker",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "positionFeeProtocol",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "positionFeeSubtractive",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "positionFeeExposure",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "positionFeeExposureMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "positionFeeExposureProtocol",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "positionFeeImpact",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "fundingMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "fundingLong",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "fundingShort",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "fundingFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "interestMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "interestLong",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "interestShort",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "interestFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "pnlMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "pnlLong",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "pnlShort",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "settlementFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "liquidationFee",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct VersionAccumulationResult",
+                    "name": "accumulationResult",
+                    "type": "tuple"
+                }
+            ],
+            "name": "PositionProcessed",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "timestamp",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "orders",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "collateral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "protection",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerReferral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerReferral",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "order",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "positionFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFeeMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFeeProtocol",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFeeSubtractive",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFeeExposure",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFeeExposureMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFeeExposureProtocol",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "positionFeeImpact",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingShort",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestShort",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pnlMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pnlLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pnlShort",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "settlementFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFee",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "accumulationResult",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_2_event_PositionProcessed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_RiskParameterUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_RiskParameterUpdated.json
@@ -1,0 +1,332 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "UFixed6",
+                            "name": "margin",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "maintenance",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "linearFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "proportionalFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "adiabaticFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "scale",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct LinearAdiabatic6",
+                            "name": "takerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "linearFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "proportionalFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "adiabaticFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "scale",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct InverseAdiabatic6",
+                            "name": "makerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerLimit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "efficiencyLimit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "liquidationFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "minRate",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "maxRate",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "targetRate",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "targetUtilization",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct UJumpRateUtilizationCurve6",
+                            "name": "utilizationCurve",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "k",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "Fixed6",
+                                    "name": "min",
+                                    "type": "int256"
+                                },
+                                {
+                                    "internalType": "Fixed6",
+                                    "name": "max",
+                                    "type": "int256"
+                                }
+                            ],
+                            "internalType": "struct PController6",
+                            "name": "pController",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "minMargin",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "minMaintenance",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "staleAfter",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "makerReceiveOnly",
+                            "type": "bool"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct RiskParameter",
+                    "name": "newRiskParameter",
+                    "type": "tuple"
+                }
+            ],
+            "name": "RiskParameterUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "margin",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "maintenance",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "linearFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "proportionalFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "adiabaticFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "scale",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "takerFee",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "linearFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "proportionalFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "adiabaticFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "scale",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "makerFee",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerLimit",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "efficiencyLimit",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "minRate",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "maxRate",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "targetRate",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "targetUtilization",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "utilizationCurve",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "k",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "min",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "max",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "pController",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "name": "minMargin",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "minMaintenance",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "staleAfter",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerReceiveOnly",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newRiskParameter",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_2_event_RiskParameterUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_RiskParameterUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_RiskParameterUpdated.json
@@ -163,7 +163,7 @@
             "name": "RiskParameterUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_Updated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_Updated.json
@@ -1,0 +1,120 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "version",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed6",
+                    "name": "newMaker",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed6",
+                    "name": "newLong",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed6",
+                    "name": "newShort",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "Fixed6",
+                    "name": "collateral",
+                    "type": "int256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "protect",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "referrer",
+                    "type": "address"
+                }
+            ],
+            "name": "Updated",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newMaker",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newLong",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newShort",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateral",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "protect",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "referrer",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_2_event_Updated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_Updated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_2_event_Updated.json
@@ -61,7 +61,7 @@
             "name": "Updated",
             "type": "event"
         },
-        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market",
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
## What?
Add support for Perennial v2.2 tables

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions, with contract addresses `0x3dd09c846149e50d412cdce968e1d912117ff937` and `0xfb4a12e285bBf9efF066362aeA7bf4E4d20b0e3b` from [here](https://github.com/equilibria-xyz/perennial-v2/pull/341/commits/7e16b46d64646b8ab963cffe895a263822e7dca1#diff-cfc41365dd1d684ac1e9cca49e9ac5c9774d6345dae39ab86d10b8012055c1a3)

Manually replaced the auto-generated
```
"contract_address": "0xfb4a12e285bBf9efF066362aeA7bf4E4d20b0e3b"
```
with
```
"contract_address": "SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market"
```