### PR TITLE
Add Aero CL pool creation events

### DIFF
--- a/parse/table_definitions_base/aerodrome/CLFactory_event_PoolCreated.json
+++ b/parse/table_definitions_base/aerodrome/CLFactory_event_PoolCreated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token0",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token1",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "int24",
+                    "name": "tickSpacing",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                }
+            ],
+            "name": "PoolCreated",
+            "type": "event"
+        },
+        "contract_address": "0x5e7bb104d84c7cb9b682aac2f3d509f5f406809a",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aerodrome",
+        "schema": [
+            {
+                "description": "",
+                "name": "token0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickSpacing",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "CLFactory_event_PoolCreated"
+    }
+}


### PR DESCRIPTION
## What?
Add support for Aerodrome concentrated liquidty pool factory creation events.

CLPool contract: https://basescan.org/address/0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A#code

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) or cli tools to build the table definitions
