### PR TITLE
Add Aero Pool_call_getReserves

### DIFF
--- a/parse/table_definitions_base/aerodrome/Pool_call_getReserves.json
+++ b/parse/table_definitions_base/aerodrome/Pool_call_getReserves.json
@@ -1,0 +1,36 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [],
+            "name": "getReserves",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_reserve0",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_reserve1",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_blockTimestampLast",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "SELECT pool FROM ref('PoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "aerodrome",
+        "schema": [],
+        "table_description": "",
+        "table_name": "Pool_call_getReserves"
+    }
+}


### PR DESCRIPTION
## What?
Add support for Aerodrome concentrated liquidty pool factory creation events.

Pool contracts: SELECT pool FROM `blockchain-etl.base_aerodrome.PoolFactory_event_PoolCreated` limit 1

e.g. https://basescan.org/address/0x2ce63497999f520cc2afaaadbcfc37afd9def4b0
## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) or cli tools to build the table definitions
