### PR TITLE
Revert "Updating json file for getReserves call function"

### DIFF
--- a/parse/table_definitions_base/aerodrome/Pool_call_getReserves.json
+++ b/parse/table_definitions_base/aerodrome/Pool_call_getReserves.json
@@ -24,58 +24,13 @@
             "type": "function"
         },
         "contract_address": "SELECT pool FROM ref('PoolFactory_event_PoolCreated')",
-        "field_mapping": {
-            "_reserve0": "reserve0",
-            "_reserve1": "reserve1",
-            "_blockTimestampLast": "blockTimestampLast"
-        },
+        "field_mapping": {},
         "type": "trace"
     },
     "table": {
         "dataset_name": "aerodrome",
-        "schema": [
-            {
-                "name": "block_timestamp",
-                "type": "TIMESTAMP"
-            },
-            {
-                "name": "block_number",
-                "type": "INTEGER"
-            },
-            {
-                "name": "transaction_hash",
-                "type": "STRING"
-            },
-            {
-                "name": "transaction_index",
-                "type": "INTEGER"
-            },
-            {
-                "name": "trace_address",
-                "type": "STRING"
-            },
-            {
-                "name": "to_address",
-                "type": "STRING"
-            },
-            {
-                "name": "status",
-                "type": "INTEGER"
-            },
-            {
-                "name": "reserve0",
-                "type": "STRING"
-            },
-            {
-                "name": "reserve1",
-                "type": "STRING"
-            },
-            {
-                "name": "blockTimestampLast",
-                "type": "STRING"
-            }
-        ],
-        "table_description": "Table containing the reserves of the pool",
+        "schema": [],
+        "table_description": "",
         "table_name": "Pool_call_getReserves"
     }
 }


### PR DESCRIPTION
Reverts nansen-ai/evmchain-etl-table-definitions#309

This change did unfortunately fail in [CI/CD on merge](https://github.com/nansen-ai/evmchain-etl-table-definitions/actions/runs/9781535208/job/27005839565), and then later when running `base_parse_aerodrome_dag` in Composer.

The main reason to revert, therefore, is to unblock other Base/Aerodrome tables by allowing the dag to succeed. Especially in view of the holiday in USA meaning that this may not be fixed properly until Monday 8 July.

---
Regarding a proper fix. Clearly the previous table definition (https://github.com/nansen-ai/evmchain-etl-table-definitions/pull/306) did not meet requirements. I don't quite understand why, which is the reason we are reverting and not attempting an immediate fix.

In any case, the JSON schema should not contain `block_timestamp` since it's getting added automatically in the load (I think), causing BQ to reject the schema for having 2 columns with same name. 

The error was:
```
Field block_timestamp already exists in schema
```