### PR TITLE
[Gauntlet] Moonwell Optimism events

### DIFF
--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_ActionPaused.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_ActionPaused.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "action",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "pauseState",
+                    "type": "bool"
+                }
+            ],
+            "name": "ActionPaused",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "action",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pauseState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_ActionPaused"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_Failure.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_Failure.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "error",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "info",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "detail",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_Failure"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_MarketEntered.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_MarketEntered.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketEntered",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_MarketEntered"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_MarketExited.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_MarketExited.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketExited",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_MarketExited"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_MarketListed.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_MarketListed.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketListed",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_MarketListed"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewBorrowCap.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewBorrowCap.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewBorrowCap",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewBorrowCap"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewBorrowCapGuardian.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewBorrowCapGuardian.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldBorrowCapGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newBorrowCapGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "NewBorrowCapGuardian",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldBorrowCapGuardian",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCapGuardian",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewBorrowCapGuardian"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewCloseFactor.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewCloseFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCloseFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCloseFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCloseFactor",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldCloseFactorMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCloseFactorMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewCloseFactor"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewCollateralFactor.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewCollateralFactor.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCollateralFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCollateralFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCollateralFactor",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldCollateralFactorMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCollateralFactorMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewCollateralFactor"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewLiquidationIncentive.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewLiquidationIncentive.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewLiquidationIncentive",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldLiquidationIncentiveMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newLiquidationIncentiveMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewLiquidationIncentive"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewPauseGuardian.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewPauseGuardian.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPauseGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPauseGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPauseGuardian",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldPauseGuardian",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPauseGuardian",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewPauseGuardian"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewPriceOracle.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewPriceOracle.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract PriceOracle",
+                    "name": "oldPriceOracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract PriceOracle",
+                    "name": "newPriceOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPriceOracle",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldPriceOracle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPriceOracle",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewPriceOracle"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewRewardDistributor.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewRewardDistributor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract MultiRewardDistributor",
+                    "name": "oldRewardDistributor",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract MultiRewardDistributor",
+                    "name": "newRewardDistributor",
+                    "type": "address"
+                }
+            ],
+            "name": "NewRewardDistributor",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldRewardDistributor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRewardDistributor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewRewardDistributor"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewSupplyCap.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewSupplyCap.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSupplyCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewSupplyCap",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewSupplyCap"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/Comptroller_event_NewSupplyCapGuardian.json
+++ b/parse/table_definitions_optimism/moonwell/Comptroller_event_NewSupplyCapGuardian.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldSupplyCapGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newSupplyCapGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "NewSupplyCapGuardian",
+            "type": "event"
+        },
+        "contract_address": "0xca889f40aae37fff165bccf69aef1e82b5c511b9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldSupplyCapGuardian",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyCapGuardian",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comptroller_event_NewSupplyCapGuardian"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_AccrueInterest.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_AccrueInterest.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "cashPrior",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "interestAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccrueInterest",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "cashPrior",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "interestAccumulated",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrowIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalBorrows",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_AccrueInterest"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_Approval.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_Approval"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_Borrow.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_Borrow.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrowAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "accountBorrows",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalBorrows",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_Borrow"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_Failure.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_Failure.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "error",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "info",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "detail",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_Failure"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_LiquidateBorrow.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_LiquidateBorrow.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "mTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateBorrow",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "liquidator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "repayAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mTokenCollateral",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "seizeTokens",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_LiquidateBorrow"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_Mint.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "minter",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mintAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mintTokens",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_Mint"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_NewAdmin.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_NewAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldAdmin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newAdmin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_NewAdmin"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_NewComptroller.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_NewComptroller.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract ComptrollerInterface",
+                    "name": "oldComptroller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract ComptrollerInterface",
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "NewComptroller",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldComptroller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newComptroller",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_NewComptroller"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_NewMarketInterestRateModel.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_NewMarketInterestRateModel.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract InterestRateModel",
+                    "name": "oldInterestRateModel",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract InterestRateModel",
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "NewMarketInterestRateModel",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldInterestRateModel",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newInterestRateModel",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_NewMarketInterestRateModel"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_NewPendingAdmin.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_NewPendingAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldPendingAdmin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPendingAdmin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_NewPendingAdmin"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_NewProtocolSeizeShare.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_NewProtocolSeizeShare.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldProtocolSeizeShareMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newProtocolSeizeShareMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewProtocolSeizeShare",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldProtocolSeizeShareMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newProtocolSeizeShareMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_NewProtocolSeizeShare"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_NewReserveFactor.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_NewReserveFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldReserveFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewReserveFactor",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldReserveFactorMantissa",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newReserveFactorMantissa",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_NewReserveFactor"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_Redeem.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_Redeem.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "redeemer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "redeemAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "redeemTokens",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_Redeem"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_RepayBorrow.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_RepayBorrow.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RepayBorrow",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "payer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "repayAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "accountBorrows",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalBorrows",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_RepayBorrow"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_ReservesAdded.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_ReservesAdded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "benefactor",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "addAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesAdded",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "benefactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "addAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalReserves",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_ReservesAdded"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_ReservesReduced.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_ReservesReduced.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "admin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesReduced",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "admin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reduceAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalReserves",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_ReservesReduced"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MToken_event_Transfer.json
+++ b/parse/table_definitions_optimism/moonwell/MToken_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT mToken FROM ref('Comptroller_event_MarketListed') group by mToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MToken_event_Transfer"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_DisbursedBorrowerRewards.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_DisbursedBorrowerRewards.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "emissionToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "totalAccrued",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DisbursedBorrowerRewards",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "emissionToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalAccrued",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_DisbursedBorrowerRewards"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_DisbursedSupplierRewards.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_DisbursedSupplierRewards.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "supplier",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "emissionToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "totalAccrued",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DisbursedSupplierRewards",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "supplier",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "emissionToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalAccrued",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_DisbursedSupplierRewards"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_FundsRescued.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_FundsRescued.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FundsRescued",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_FundsRescued"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_GlobalBorrowIndexUpdated.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_GlobalBorrowIndexUpdated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "emissionToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "newTimestamp",
+                    "type": "uint32"
+                }
+            ],
+            "name": "GlobalBorrowIndexUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "emissionToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTimestamp",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_GlobalBorrowIndexUpdated"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_GlobalSupplyIndexUpdated.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_GlobalSupplyIndexUpdated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "emissionToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSupplyIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "newSupplyGlobalTimestamp",
+                    "type": "uint32"
+                }
+            ],
+            "name": "GlobalSupplyIndexUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "emissionToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyGlobalTimestamp",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_GlobalSupplyIndexUpdated"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_Initialized.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "version",
+                    "type": "uint8"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_Initialized"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_InsufficientTokensToEmit.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_InsufficientTokensToEmit.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address payable",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "rewardToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "InsufficientTokensToEmit",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "rewardToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_InsufficientTokensToEmit"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewBorrowRewardSpeed.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewBorrowRewardSpeed.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "emissionToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldRewardSpeed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newRewardSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewBorrowRewardSpeed",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "emissionToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldRewardSpeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRewardSpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_NewBorrowRewardSpeed"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewConfigCreated.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewConfigCreated.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "emissionToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "supplySpeed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "borrowSpeed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endTime",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewConfigCreated",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "emissionToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "supplySpeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrowSpeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "endTime",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_NewConfigCreated"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewEmissionCap.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewEmissionCap.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldEmissionCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newEmissionCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewEmissionCap",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldEmissionCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newEmissionCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_NewEmissionCap"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewEmissionConfigOwner.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewEmissionConfigOwner.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "emissionToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "currentOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "NewEmissionConfigOwner",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "emissionToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_NewEmissionConfigOwner"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewPauseGuardian.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewPauseGuardian.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPauseGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPauseGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPauseGuardian",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldPauseGuardian",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPauseGuardian",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_NewPauseGuardian"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewRewardEndTime.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewRewardEndTime.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "emissionToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentEndTime",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newEndTime",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewRewardEndTime",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "emissionToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentEndTime",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newEndTime",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_NewRewardEndTime"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewSupplyRewardSpeed.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_NewSupplyRewardSpeed.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract MToken",
+                    "name": "mToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "emissionToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldRewardSpeed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newRewardSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewSupplyRewardSpeed",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "mToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "emissionToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldRewardSpeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRewardSpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_NewSupplyRewardSpeed"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_Paused.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_Paused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_Paused"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_RewardsPaused.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_RewardsPaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "RewardsPaused",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_RewardsPaused"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_RewardsUnpaused.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_RewardsUnpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "RewardsUnpaused",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_RewardsUnpaused"
+    }
+}

--- a/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_Unpaused.json
+++ b/parse/table_definitions_optimism/moonwell/MultiRewardDistributor_event_Unpaused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0xf9524bfa18c19c3e605fbfe8dfd05c6e967574aa",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "moonwell",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MultiRewardDistributor_event_Unpaused"
+    }
+}


### PR DESCRIPTION
## What?
Adds support for Moonwell Optimism events (Comptroller, MToken, and MultiRewardDistributor)

## How? 
 I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions, replacing contract addresses in json files with proxy addresses or select statement where applicable