### PR TITLE
Replace Perennial MarketFactory contract address with proxy address

### DIFF
--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Initialized.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Initialized.json
@@ -13,7 +13,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_InstanceRegistered.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_InstanceRegistered.json
@@ -13,7 +13,7 @@
             "name": "InstanceRegistered",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_MarketCreated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_MarketCreated.json
@@ -31,7 +31,7 @@
             "name": "MarketCreated",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_OperatorUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_OperatorUpdated.json
@@ -25,7 +25,7 @@
             "name": "OperatorUpdated",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_OwnerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_OwnerUpdated.json
@@ -13,7 +13,7 @@
             "name": "OwnerUpdated",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_ParameterUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_ParameterUpdated.json
@@ -55,7 +55,7 @@
             "name": "ParameterUpdated",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Paused.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Paused.json
@@ -6,7 +6,7 @@
             "name": "Paused",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_PauserUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_PauserUpdated.json
@@ -13,7 +13,7 @@
             "name": "PauserUpdated",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_PendingOwnerUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_PendingOwnerUpdated.json
@@ -13,7 +13,7 @@
             "name": "PendingOwnerUpdated",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_ReferralFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_ReferralFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "ReferralFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Unpaused.json
+++ b/parse/table_definitions_arbitrum/perennial/MarketFactory_v2_2_event_Unpaused.json
@@ -6,7 +6,7 @@
             "name": "Unpaused",
             "type": "event"
         },
-        "contract_address": "0x3dd09c846149e50d412cdce968e1d912117ff937",
+        "contract_address": "0xdad8a103473dfd47f90168a0e46766ed48e26ec7",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
## What?
Contract address was incorrect; the abi-parser output had the implementation contract address, but the logs are associated with the transparent proxy address.

## How? 
Used the same proxy address as for the v2 events.
