### PR TITLE
ingesting call data from Vertex spotEngine contract

### DIFF
--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_addProduct.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_addProduct.json
@@ -1,0 +1,156 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "uint32",
+                    "name": "quoteId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "address",
+                    "name": "book",
+                    "type": "address"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "sizeIncrement",
+                    "type": "int128"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "minSize",
+                    "type": "int128"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "lpSpreadX18",
+                    "type": "int128"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "interestInflectionUtilX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "interestFloorX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "interestSmallCapX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "interestLargeCapX18",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct ISpotEngine.Config",
+                    "name": "config",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "int32",
+                            "name": "longWeightInitial",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "shortWeightInitial",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "longWeightMaintenance",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "shortWeightMaintenance",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "priceX18",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct RiskHelper.RiskStore",
+                    "name": "riskStore",
+                    "type": "tuple"
+                }
+            ],
+            "name": "addProduct",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "quoteId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "book",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sizeIncrement",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "minSize",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "lpSpreadX18",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "config",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "riskStore",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_addProduct"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_assertUtilization.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_assertUtilization.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                }
+            ],
+            "name": "assertUtilization",
+            "outputs": [],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_assertUtilization"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_burnLp.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_burnLp.json
@@ -1,0 +1,63 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "amountLp",
+                    "type": "int128"
+                }
+            ],
+            "name": "burnLp",
+            "outputs": [
+                {
+                    "internalType": "int128",
+                    "name": "amountBase",
+                    "type": "int128"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "amountQuote",
+                    "type": "int128"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountLp",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_burnLp"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_decomposeLps.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_decomposeLps.json
@@ -1,0 +1,58 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "isoGroup",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "liquidatee",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "liquidator",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "decomposeLps",
+            "outputs": [
+                {
+                    "internalType": "int128",
+                    "name": "liquidationFees",
+                    "type": "int128"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "isoGroup",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidatee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidator",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_decomposeLps"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getBalance.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getBalance.json
@@ -1,0 +1,60 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getBalance",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int128",
+                            "name": "amount",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "lastCumulativeMultiplierX18",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct ISpotEngine.Balance",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getBalance"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getClearinghouse.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getClearinghouse.json
@@ -1,0 +1,26 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [],
+            "name": "getClearinghouse",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getClearinghouse"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getConfig.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getConfig.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                }
+            ],
+            "name": "getConfig",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "interestInflectionUtilX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "interestFloorX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "interestSmallCapX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "interestLargeCapX18",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct ISpotEngine.Config",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getConfig"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getCoreRisk.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getCoreRisk.json
@@ -1,0 +1,75 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "enum IProductEngine.HealthType",
+                    "name": "healthType",
+                    "type": "uint8"
+                }
+            ],
+            "name": "getCoreRisk",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int128",
+                            "name": "amount",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "price",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "longWeight",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct IProductEngine.CoreRisk",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "healthType",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getCoreRisk"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getEndpoint.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getEndpoint.json
@@ -1,0 +1,26 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [],
+            "name": "getEndpoint",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getEndpoint"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getEngineType.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getEngineType.json
@@ -1,0 +1,26 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [],
+            "name": "getEngineType",
+            "outputs": [
+                {
+                    "internalType": "enum IProductEngine.EngineType",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getEngineType"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getHealthContribution.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getHealthContribution.json
@@ -1,0 +1,48 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "enum IProductEngine.HealthType",
+                    "name": "healthType",
+                    "type": "uint8"
+                }
+            ],
+            "name": "getHealthContribution",
+            "outputs": [
+                {
+                    "internalType": "int128",
+                    "name": "health",
+                    "type": "int128"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "healthType",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getHealthContribution"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getMinDepositRate.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getMinDepositRate.json
@@ -1,0 +1,38 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                }
+            ],
+            "name": "getMinDepositRate",
+            "outputs": [
+                {
+                    "internalType": "int128",
+                    "name": "",
+                    "type": "int128"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getMinDepositRate"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getProductIds.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getProductIds.json
@@ -1,0 +1,38 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "isoGroup",
+                    "type": "uint32"
+                }
+            ],
+            "name": "getProductIds",
+            "outputs": [
+                {
+                    "internalType": "uint32[]",
+                    "name": "",
+                    "type": "uint32[]"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "isoGroup",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getProductIds"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getRisk.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getRisk.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                }
+            ],
+            "name": "getRisk",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int128",
+                            "name": "longWeightInitialX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "shortWeightInitialX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "longWeightMaintenanceX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "shortWeightMaintenanceX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "priceX18",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct RiskHelper.Risk",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getRisk"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getStateAndBalance.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getStateAndBalance.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getStateAndBalance",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int128",
+                            "name": "cumulativeDepositsMultiplierX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "cumulativeBorrowsMultiplierX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "totalDepositsNormalized",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "totalBorrowsNormalized",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct ISpotEngine.State",
+                    "name": "",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "int128",
+                            "name": "amount",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "lastCumulativeMultiplierX18",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct ISpotEngine.Balance",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getStateAndBalance"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getStatesAndBalances.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getStatesAndBalances.json
@@ -1,0 +1,145 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getStatesAndBalances",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int128",
+                            "name": "supply",
+                            "type": "int128"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "int128",
+                                    "name": "amount",
+                                    "type": "int128"
+                                },
+                                {
+                                    "internalType": "int128",
+                                    "name": "lastCumulativeMultiplierX18",
+                                    "type": "int128"
+                                }
+                            ],
+                            "internalType": "struct ISpotEngine.Balance",
+                            "name": "quote",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "int128",
+                                    "name": "amount",
+                                    "type": "int128"
+                                },
+                                {
+                                    "internalType": "int128",
+                                    "name": "lastCumulativeMultiplierX18",
+                                    "type": "int128"
+                                }
+                            ],
+                            "internalType": "struct ISpotEngine.Balance",
+                            "name": "base",
+                            "type": "tuple"
+                        }
+                    ],
+                    "internalType": "struct ISpotEngine.LpState",
+                    "name": "",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "int128",
+                            "name": "amount",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct ISpotEngine.LpBalance",
+                    "name": "",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "int128",
+                            "name": "cumulativeDepositsMultiplierX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "cumulativeBorrowsMultiplierX18",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "totalDepositsNormalized",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "totalBorrowsNormalized",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct ISpotEngine.State",
+                    "name": "",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "int128",
+                            "name": "amount",
+                            "type": "int128"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "lastCumulativeMultiplierX18",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct ISpotEngine.Balance",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getStatesAndBalances"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getToken.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getToken.json
@@ -1,0 +1,38 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                }
+            ],
+            "name": "getToken",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getToken"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getWithdrawFee.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_getWithdrawFee.json
@@ -1,0 +1,38 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                }
+            ],
+            "name": "getWithdrawFee",
+            "outputs": [
+                {
+                    "internalType": "int128",
+                    "name": "",
+                    "type": "int128"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_getWithdrawFee"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_initialize.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_initialize.json
@@ -1,0 +1,72 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_clearinghouse",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_offchainExchange",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_quote",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_endpoint",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_admin",
+                    "type": "address"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "_clearinghouse",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_offchainExchange",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_quote",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_endpoint",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_admin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_initialize"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_manualAssert.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_manualAssert.json
@@ -1,0 +1,42 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "int128[]",
+                    "name": "totalDeposits",
+                    "type": "int128[]"
+                },
+                {
+                    "internalType": "int128[]",
+                    "name": "totalBorrows",
+                    "type": "int128[]"
+                }
+            ],
+            "name": "manualAssert",
+            "outputs": [],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "totalDeposits",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalBorrows",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_manualAssert"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_migrationFlag.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_migrationFlag.json
@@ -1,0 +1,26 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [],
+            "name": "migrationFlag",
+            "outputs": [
+                {
+                    "internalType": "uint64",
+                    "name": "",
+                    "type": "uint64"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [],
+        "table_description": "",
+        "table_name": "SpotEngine_call_migrationFlag"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_mintLp.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_mintLp.json
@@ -1,0 +1,72 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "amountBase",
+                    "type": "int128"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "quoteAmountLow",
+                    "type": "int128"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "quoteAmountHigh",
+                    "type": "int128"
+                }
+            ],
+            "name": "mintLp",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountBase",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "quoteAmountLow",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "quoteAmountHigh",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_mintLp"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_owner.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_owner.json
@@ -1,0 +1,26 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [],
+        "table_description": "",
+        "table_name": "SpotEngine_call_owner"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_renounceOwnership.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_renounceOwnership.json
@@ -1,0 +1,20 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [],
+            "name": "renounceOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [],
+        "table_description": "",
+        "table_name": "SpotEngine_call_renounceOwnership"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_socializeSubaccount.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_socializeSubaccount.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "socializeSubaccount",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_socializeSubaccount"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_swapLp.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_swapLp.json
@@ -1,0 +1,63 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "baseDelta",
+                    "type": "int128"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "quoteDelta",
+                    "type": "int128"
+                }
+            ],
+            "name": "swapLp",
+            "outputs": [
+                {
+                    "internalType": "int128",
+                    "name": "",
+                    "type": "int128"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "",
+                    "type": "int128"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "baseDelta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "quoteDelta",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_swapLp"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_transferOwnership.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_transferOwnership.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "transferOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_transferOwnership"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateBalance.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateBalance.json
@@ -1,0 +1,62 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "amountDelta",
+                    "type": "int128"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "quoteDelta",
+                    "type": "int128"
+                }
+            ],
+            "name": "updateBalance",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountDelta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "quoteDelta",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_updateBalance"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateMinDepositRate.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateMinDepositRate.json
@@ -1,0 +1,42 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "minDepositRateX18",
+                    "type": "int128"
+                }
+            ],
+            "name": "updateMinDepositRate",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "minDepositRateX18",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_updateMinDepositRate"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updatePrice.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updatePrice.json
@@ -1,0 +1,42 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "priceX18",
+                    "type": "int128"
+                }
+            ],
+            "name": "updatePrice",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "priceX18",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_updatePrice"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateProduct.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateProduct.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "rawTxn",
+                    "type": "bytes"
+                }
+            ],
+            "name": "updateProduct",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "rawTxn",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_updateProduct"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateQuoteFromInsurance.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateQuoteFromInsurance.json
@@ -1,0 +1,48 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "subaccount",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "int128",
+                    "name": "insurance",
+                    "type": "int128"
+                }
+            ],
+            "name": "updateQuoteFromInsurance",
+            "outputs": [
+                {
+                    "internalType": "int128",
+                    "name": "",
+                    "type": "int128"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "subaccount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "insurance",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_updateQuoteFromInsurance"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateRisk.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateRisk.json
@@ -1,0 +1,69 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "productId",
+                    "type": "uint32"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "int32",
+                            "name": "longWeightInitial",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "shortWeightInitial",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "longWeightMaintenance",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "shortWeightMaintenance",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "int128",
+                            "name": "priceX18",
+                            "type": "int128"
+                        }
+                    ],
+                    "internalType": "struct RiskHelper.RiskStore",
+                    "name": "riskStore",
+                    "type": "tuple"
+                }
+            ],
+            "name": "updateRisk",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "productId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "riskStore",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_updateRisk"
+    }
+}

--- a/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateStates.json
+++ b/parse/table_definitions_arbitrum/vertex/SpotEngine_call_updateStates.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint128",
+                    "name": "dt",
+                    "type": "uint128"
+                }
+            ],
+            "name": "updateStates",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x6b1c769887e51393e2f727db0ea7aa0a2f8adabb",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "vertex",
+        "schema": [
+            {
+                "description": "",
+                "name": "dt",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SpotEngine_call_updateStates"
+    }
+}


### PR DESCRIPTION
## What?
Add support for Vertex contract events 

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions
Contract address of the SpotEngine contract for Vertex protocol (Arbitrum): 0x6b1C769887e51393e2f727db0eA7AA0a2f8ADAbb
