### PR TITLE
[Gauntlet] Update Synonym interest rate calculator addresses

### DIFF
--- a/parse/table_definitions_arbitrum/synonym/PiecewiseInterestRate_event_ModelSet.json
+++ b/parse/table_definitions_arbitrum/synonym/PiecewiseInterestRate_event_ModelSet.json
@@ -30,7 +30,7 @@
             "name": "ModelSet",
             "type": "event"
         },
-        "contract_address": "SELECT interestRateCalculator FROM ref('AssetRegistry_event_AssetRegistered') group by interestRateCalculator",
+        "contract_address": "SELECT interestRateCalculator FROM ref('AssetRegistry_event_SetAssetParams') GROUP BY interestRateCalculator",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
## What?
ie: Pulls interestRateCalculator from the asset registry SetParams event instead of AssetRegistered event to capture updated IR contracts after initialization.

## How? 
ie: cross referenced the interestRateCalculator addresses present in the AssetRegistry getAssetInfo response to ensure they are present in SetParams where they were missing in AssetRegistered