### PR TITLE
Adding ArrakisV2 Mint and Burn Events

### DIFF
--- a/parse/table_definitions_arbitrum/arrakis/ArrakisV2_event_LogBurn.json
+++ b/parse/table_definitions_arbitrum/arrakis/ArrakisV2_event_LogBurn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "burnAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0Out",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1Out",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogBurn",
+            "type": "event"
+        },
+        "contract_address": "SELECT vault FROM ref('ArrakisV2_event_VaultCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "arrakisv2_event_tables",
+        "schema": [
+            {
+                "description": "",
+                "name": "receiver",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "burnAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0Out",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1Out",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArrakisV2_event_LogBurn"
+    }
+}

--- a/parse/table_definitions_arbitrum/arrakis/ArrakisV2_event_LogBurn.json
+++ b/parse/table_definitions_arbitrum/arrakis/ArrakisV2_event_LogBurn.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "arrakisv2_event_tables",
+        "dataset_name": "arrakis",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_arbitrum/arrakis/ArrakisV2_event_LogMint.json
+++ b/parse/table_definitions_arbitrum/arrakis/ArrakisV2_event_LogMint.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0In",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1In",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogMint",
+            "type": "event"
+        },
+        "contract_address": "SELECT vault FROM ref('ArrakisV2_event_VaultCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "arrakisv2_event_tables",
+        "schema": [
+            {
+                "description": "",
+                "name": "receiver",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mintAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0In",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1In",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArrakisV2_event_LogMint"
+    }
+}

--- a/parse/table_definitions_arbitrum/arrakis/ArrakisV2_event_LogMint.json
+++ b/parse/table_definitions_arbitrum/arrakis/ArrakisV2_event_LogMint.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "arrakisv2_event_tables",
+        "dataset_name": "arrakis",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_base/arrakis/ArrakisV2_event_LogBurn.json
+++ b/parse/table_definitions_base/arrakis/ArrakisV2_event_LogBurn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "burnAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0Out",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1Out",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogBurn",
+            "type": "event"
+        },
+        "contract_address": "SELECT vault FROM ref('ArrakisV2_event_VaultCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "arrakisv2_event_tables",
+        "schema": [
+            {
+                "description": "",
+                "name": "receiver",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "burnAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0Out",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1Out",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArrakisV2_event_LogBurn"
+    }
+}

--- a/parse/table_definitions_base/arrakis/ArrakisV2_event_LogBurn.json
+++ b/parse/table_definitions_base/arrakis/ArrakisV2_event_LogBurn.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "arrakisv2_event_tables",
+        "dataset_name": "arrakis",
         "schema": [
             {
                 "description": "",

--- a/parse/table_definitions_base/arrakis/ArrakisV2_event_LogMint.json
+++ b/parse/table_definitions_base/arrakis/ArrakisV2_event_LogMint.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0In",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1In",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogMint",
+            "type": "event"
+        },
+        "contract_address": "SELECT vault FROM ref('ArrakisV2_event_VaultCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "arrakisv2_event_tables",
+        "schema": [
+            {
+                "description": "",
+                "name": "receiver",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mintAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0In",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1In",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ArrakisV2_event_LogMint"
+    }
+}

--- a/parse/table_definitions_base/arrakis/ArrakisV2_event_LogMint.json
+++ b/parse/table_definitions_base/arrakis/ArrakisV2_event_LogMint.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "arrakisv2_event_tables",
+        "dataset_name": "arrakis",
         "schema": [
             {
                 "description": "",


### PR DESCRIPTION
## What?
- Adding support for arrakisV2 mint and burn events to arbitrum and base, to improve performance tracking.

## How? 
- I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions