### PR TITLE
[Gauntlet] Perennial v2.3 events

### DIFF
--- a/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_AccountPositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_AccountPositionProcessed.json
@@ -1,0 +1,273 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "timestamp",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "orders",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "collateral",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "protection",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerReferral",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerReferral",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct Order",
+                    "name": "order",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "Fixed6",
+                            "name": "collateral",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "priceOverride",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "tradeFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "offset",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "settlementFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "liquidationFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "subtractiveFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "solverFee",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CheckpointAccumulationResult",
+                    "name": "accumulationResult",
+                    "type": "tuple"
+                }
+            ],
+            "name": "AccountPositionProcessed",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market UNION ALL SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "orderId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "timestamp",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "orders",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "collateral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "protection",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerReferral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerReferral",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "order",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "collateral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "priceOverride",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "tradeFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offset",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "settlementFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "subtractiveFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "solverFee",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "accumulationResult",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_3_event_AccountPositionProcessed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_FeeClaimed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_FeeClaimed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "UFixed6",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FeeClaimed",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market UNION ALL SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receiver",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_3_event_FeeClaimed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_OrderCreated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_OrderCreated.json
@@ -1,0 +1,275 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "timestamp",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "orders",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "collateral",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "protection",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerReferral",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerReferral",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct Order",
+                    "name": "order",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orders",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "notional",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "referral",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct Guarantee",
+                    "name": "guarantee",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "orderReferrer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "guaranteeReferrer",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCreated",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market UNION ALL SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "timestamp",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "orders",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "collateral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "protection",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerReferral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerReferral",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "order",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "orders",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "notional",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "referral",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "guarantee",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "liquidator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "orderReferrer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "guaranteeReferrer",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_3_event_OrderCreated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_ParameterUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_ParameterUpdated.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "UFixed6",
+                            "name": "fundingFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "interestFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "riskFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "maxPendingGlobal",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "maxPendingLocal",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "maxPriceDeviation",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "closed",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "settle",
+                            "type": "bool"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct MarketParameter",
+                    "name": "newParameter",
+                    "type": "tuple"
+                }
+            ],
+            "name": "ParameterUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market UNION ALL SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "fundingFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "riskFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "maxPendingGlobal",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "maxPendingLocal",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "maxPriceDeviation",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "closed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "settle",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newParameter",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_3_event_ParameterUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_PositionProcessed.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_PositionProcessed.json
@@ -1,0 +1,392 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "timestamp",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "orders",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "collateral",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "longNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortPos",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "shortNeg",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "protection",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerReferral",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "takerReferral",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct Order",
+                    "name": "order",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "UFixed6",
+                            "name": "tradeFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "subtractiveFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "tradeOffset",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "tradeOffsetMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "tradeOffsetMarket",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "adiabaticExposure",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "adiabaticExposureMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "adiabaticExposureMarket",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "fundingMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "fundingLong",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "fundingShort",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "fundingFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "interestMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "interestLong",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "interestShort",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "interestFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "pnlMaker",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "pnlLong",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "Fixed6",
+                            "name": "pnlShort",
+                            "type": "int256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "settlementFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "liquidationFee",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct VersionAccumulationResult",
+                    "name": "accumulationResult",
+                    "type": "tuple"
+                }
+            ],
+            "name": "PositionProcessed",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market UNION ALL SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "timestamp",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "orders",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "collateral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "longNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortPos",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "shortNeg",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "protection",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerReferral",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "takerReferral",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "order",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "tradeFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "subtractiveFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "tradeOffset",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "tradeOffsetMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "tradeOffsetMarket",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "adiabaticExposure",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "adiabaticExposureMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "adiabaticExposureMarket",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingShort",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fundingFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestShort",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "interestFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pnlMaker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pnlLong",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pnlShort",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "settlementFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFee",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "accumulationResult",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_3_event_PositionProcessed"
+    }
+}

--- a/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_RiskParameterUpdated.json
+++ b/parse/table_definitions_arbitrum/perennial/Market_v2_3_event_RiskParameterUpdated.json
@@ -1,0 +1,322 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "UFixed6",
+                            "name": "margin",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "maintenance",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "linearFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "proportionalFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "adiabaticFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "scale",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct LinearAdiabatic6",
+                            "name": "takerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "linearFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "proportionalFee",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "scale",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct NoopAdiabatic6",
+                            "name": "makerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "makerLimit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "efficiencyLimit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "liquidationFee",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "minRate",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "maxRate",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "targetRate",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "targetUtilization",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct UJumpRateUtilizationCurve6",
+                            "name": "utilizationCurve",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "UFixed6",
+                                    "name": "k",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "Fixed6",
+                                    "name": "min",
+                                    "type": "int256"
+                                },
+                                {
+                                    "internalType": "Fixed6",
+                                    "name": "max",
+                                    "type": "int256"
+                                }
+                            ],
+                            "internalType": "struct PController6",
+                            "name": "pController",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "minMargin",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "UFixed6",
+                            "name": "minMaintenance",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "staleAfter",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "makerReceiveOnly",
+                            "type": "bool"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct RiskParameter",
+                    "name": "newRiskParameter",
+                    "type": "tuple"
+                }
+            ],
+            "name": "RiskParameterUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market UNION ALL SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "perennial",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "margin",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "maintenance",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "linearFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "proportionalFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "adiabaticFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "scale",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "takerFee",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "linearFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "proportionalFee",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "scale",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "makerFee",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerLimit",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "efficiencyLimit",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "minRate",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "maxRate",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "targetRate",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "targetUtilization",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "utilizationCurve",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "k",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "min",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "max",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "pController",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "name": "minMargin",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "minMaintenance",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "staleAfter",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "makerReceiveOnly",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newRiskParameter",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Market_v2_3_event_RiskParameterUpdated"
+    }
+}


### PR DESCRIPTION
## What?
Add support for Perennial v2.3 tables

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions, with contract address `0x17EBcA0060C3e84812ab4e208Cc33e5FD8A3b255 ` from [here](https://github.com/equilibria-xyz/perennial-v2/blob/cead8505df73033c684a6d8da3c65169a1db6c07/packages/perennial-deploy/deployments/arbitrum/MarketImpl.json)

Manually replaced the auto-generated
```
"contract_address": "0x17ebca0060c3e84812ab4e208cc33e5fd8a3b255"
```
with
```
"contract_address": "SELECT market FROM ref('MarketFactory_v2_event_MarketCreated') GROUP BY market UNION ALL SELECT market FROM ref('MarketFactory_v2_2_event_MarketCreated') GROUP BY market"
```