### PR TITLE
[Gauntlet] Euler V2 Factory events

### DIFF
--- a/parse/table_definitions_base/euler_v2/GenericFactory_event_Genesis.json
+++ b/parse/table_definitions_base/euler_v2/GenericFactory_event_Genesis.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Genesis",
+            "type": "event"
+        },
+        "contract_address": "0x7f321498a801a191a93c840750ed637149ddf8d0",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "euler_v2",
+        "schema": [],
+        "table_description": "",
+        "table_name": "GenericFactory_event_Genesis"
+    }
+}

--- a/parse/table_definitions_base/euler_v2/GenericFactory_event_ProxyCreated.json
+++ b/parse/table_definitions_base/euler_v2/GenericFactory_event_ProxyCreated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "upgradeable",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "trailingData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "ProxyCreated",
+            "type": "event"
+        },
+        "contract_address": "0x7f321498a801a191a93c840750ed637149ddf8d0",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "euler_v2",
+        "schema": [
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "upgradeable",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "trailingData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GenericFactory_event_ProxyCreated"
+    }
+}

--- a/parse/table_definitions_base/euler_v2/GenericFactory_event_SetImplementation.json
+++ b/parse/table_definitions_base/euler_v2/GenericFactory_event_SetImplementation.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "SetImplementation",
+            "type": "event"
+        },
+        "contract_address": "0x7f321498a801a191a93c840750ed637149ddf8d0",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "euler_v2",
+        "schema": [
+            {
+                "description": "",
+                "name": "newImplementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GenericFactory_event_SetImplementation"
+    }
+}

--- a/parse/table_definitions_base/euler_v2/GenericFactory_event_SetUpgradeAdmin.json
+++ b/parse/table_definitions_base/euler_v2/GenericFactory_event_SetUpgradeAdmin.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newUpgradeAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "SetUpgradeAdmin",
+            "type": "event"
+        },
+        "contract_address": "0x7f321498a801a191a93c840750ed637149ddf8d0",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "euler_v2",
+        "schema": [
+            {
+                "description": "",
+                "name": "newUpgradeAdmin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GenericFactory_event_SetUpgradeAdmin"
+    }
+}


### PR DESCRIPTION
## What?
ie: Add support for Euler V2 Generic Factory events

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions


This will enable support for vault events, as we will pull vault addresses from the ProxyCreated event output