### PR TITLE
fix: typo in BigQuery fallback dataset name

### DIFF
--- a/generate_parse_sql.py
+++ b/generate_parse_sql.py
@@ -7,7 +7,7 @@ import os
 
 # Define BigQuery project and dataset for each chain
 CHAIN_BQ_REFS = {
-    'unknown': '`notfound.notfond`',
+    'unknown': '`notfound.notfound`',
     'bsc': '`nansen-datasets-prod.crypto_bsc_v2`',
     'optimism': '`nansen-datasets-prod.crypto_optimism_v2`',
     'arbitrum': '`nansen-datasets-prod.crypto_arbitrum_v2`',


### PR DESCRIPTION
Fixed typo in **CHAIN_BQ_REFS** dictionary: notfond → notfound