### PR TITLE
add events for compound optimism MarketUpdateProposerwq

### DIFF
--- a/parse/table_definitions_optimism/compound/MarketUpdateProposer_event_MarketUpdateProposalCreated.json
+++ b/parse/table_definitions_optimism/compound/MarketUpdateProposer_event_MarketUpdateProposalCreated.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "proposer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address[]",
+                    "name": "targets",
+                    "type": "address[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "values",
+                    "type": "uint256[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string[]",
+                    "name": "signatures",
+                    "type": "string[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes[]",
+                    "name": "calldatas",
+                    "type": "bytes[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "description",
+                    "type": "string"
+                }
+            ],
+            "name": "MarketUpdateProposalCreated",
+            "type": "event"
+        },
+        "contract_address": "0xb6ef3ac71e9bacf1f4b9426c149d855bfc4415f9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proposer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "targets",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "values",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "signatures",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "calldatas",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "description",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MarketUpdateProposer_event_MarketUpdateProposalCreated"
+    }
+}

--- a/parse/table_definitions_optimism/compound/MarketUpdateProposer_event_MarketUpdateProposalExecuted.json
+++ b/parse/table_definitions_optimism/compound/MarketUpdateProposer_event_MarketUpdateProposalExecuted.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MarketUpdateProposalExecuted",
+            "type": "event"
+        },
+        "contract_address": "0xb6ef3ac71e9bacf1f4b9426c149d855bfc4415f9",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MarketUpdateProposer_event_MarketUpdateProposalExecuted"
+    }
+}


### PR DESCRIPTION
## What?
ie: Add support for Compound MarketUpdateProposer events on Optimism

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) or cli tools to build the table definitions

