### PR TITLE
ingesting poolManager for univ4 - optimism, arbitrum, base

### DIFF
--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Approval.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Approval.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Approval"
+    }
+}

--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Donate.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Donate.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Donate",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Donate"
+    }
+}

--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Initialize.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Initialize.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "Currency",
+                    "name": "currency0",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "Currency",
+                    "name": "currency1",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint24",
+                    "name": "fee",
+                    "type": "uint24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tickSpacing",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IHooks",
+                    "name": "hooks",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint160",
+                    "name": "sqrtPriceX96",
+                    "type": "uint160"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tick",
+                    "type": "int24"
+                }
+            ],
+            "name": "Initialize",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currency0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currency1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickSpacing",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "hooks",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sqrtPriceX96",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tick",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Initialize"
+    }
+}

--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_ModifyLiquidity.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_ModifyLiquidity.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tickLower",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tickUpper",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int256",
+                    "name": "liquidityDelta",
+                    "type": "int256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "salt",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "ModifyLiquidity",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickLower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickUpper",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidityDelta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "salt",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_ModifyLiquidity"
+    }
+}

--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_OperatorSet.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_OperatorSet.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "approved",
+                    "type": "bool"
+                }
+            ],
+            "name": "OperatorSet",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "approved",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_OperatorSet"
+    }
+}

--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_OwnershipTransferred.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_OwnershipTransferred"
+    }
+}

--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_ProtocolFeeControllerUpdated.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_ProtocolFeeControllerUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "protocolFeeController",
+                    "type": "address"
+                }
+            ],
+            "name": "ProtocolFeeControllerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "protocolFeeController",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_ProtocolFeeControllerUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_ProtocolFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_ProtocolFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint24",
+                    "name": "protocolFee",
+                    "type": "uint24"
+                }
+            ],
+            "name": "ProtocolFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "protocolFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_ProtocolFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Swap.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Swap.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int128",
+                    "name": "amount0",
+                    "type": "int128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int128",
+                    "name": "amount1",
+                    "type": "int128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint160",
+                    "name": "sqrtPriceX96",
+                    "type": "uint160"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "liquidity",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tick",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint24",
+                    "name": "fee",
+                    "type": "uint24"
+                }
+            ],
+            "name": "Swap",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sqrtPriceX96",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidity",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tick",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Swap"
+    }
+}

--- a/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Transfer.json
+++ b/parse/table_definitions_arbitrum/uniswap/uniswapv4/PoolManager_event_Transfer.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Transfer"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Approval.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Approval.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Approval"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Donate.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Donate.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Donate",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Donate"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Initialize.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Initialize.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "Currency",
+                    "name": "currency0",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "Currency",
+                    "name": "currency1",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint24",
+                    "name": "fee",
+                    "type": "uint24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tickSpacing",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IHooks",
+                    "name": "hooks",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint160",
+                    "name": "sqrtPriceX96",
+                    "type": "uint160"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tick",
+                    "type": "int24"
+                }
+            ],
+            "name": "Initialize",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currency0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currency1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickSpacing",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "hooks",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sqrtPriceX96",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tick",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Initialize"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_ModifyLiquidity.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_ModifyLiquidity.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tickLower",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tickUpper",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int256",
+                    "name": "liquidityDelta",
+                    "type": "int256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "salt",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "ModifyLiquidity",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickLower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickUpper",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidityDelta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "salt",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_ModifyLiquidity"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_OperatorSet.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_OperatorSet.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "approved",
+                    "type": "bool"
+                }
+            ],
+            "name": "OperatorSet",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "approved",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_OperatorSet"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_OwnershipTransferred.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_OwnershipTransferred"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_ProtocolFeeControllerUpdated.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_ProtocolFeeControllerUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "protocolFeeController",
+                    "type": "address"
+                }
+            ],
+            "name": "ProtocolFeeControllerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "protocolFeeController",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_ProtocolFeeControllerUpdated"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_ProtocolFeeUpdated.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_ProtocolFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint24",
+                    "name": "protocolFee",
+                    "type": "uint24"
+                }
+            ],
+            "name": "ProtocolFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "protocolFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_ProtocolFeeUpdated"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Swap.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Swap.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int128",
+                    "name": "amount0",
+                    "type": "int128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int128",
+                    "name": "amount1",
+                    "type": "int128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint160",
+                    "name": "sqrtPriceX96",
+                    "type": "uint160"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "liquidity",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tick",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint24",
+                    "name": "fee",
+                    "type": "uint24"
+                }
+            ],
+            "name": "Swap",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sqrtPriceX96",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidity",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tick",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Swap"
+    }
+}

--- a/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Transfer.json
+++ b/parse/table_definitions_base/uniswap/uniswapv4/PoolManager_event_Transfer.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x498581ff718922c3f8e6a244956af099b2652b2b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Transfer"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Approval.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Approval.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Approval"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Donate.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Donate.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Donate",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Donate"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Initialize.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Initialize.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "Currency",
+                    "name": "currency0",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "Currency",
+                    "name": "currency1",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint24",
+                    "name": "fee",
+                    "type": "uint24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tickSpacing",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IHooks",
+                    "name": "hooks",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint160",
+                    "name": "sqrtPriceX96",
+                    "type": "uint160"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tick",
+                    "type": "int24"
+                }
+            ],
+            "name": "Initialize",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currency0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currency1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickSpacing",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "hooks",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sqrtPriceX96",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tick",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Initialize"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_ModifyLiquidity.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_ModifyLiquidity.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tickLower",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tickUpper",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int256",
+                    "name": "liquidityDelta",
+                    "type": "int256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "salt",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "ModifyLiquidity",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickLower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tickUpper",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidityDelta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "salt",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_ModifyLiquidity"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_OperatorSet.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_OperatorSet.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "approved",
+                    "type": "bool"
+                }
+            ],
+            "name": "OperatorSet",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "approved",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_OperatorSet"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_OwnershipTransferred.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_OwnershipTransferred"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_ProtocolFeeControllerUpdated.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_ProtocolFeeControllerUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "protocolFeeController",
+                    "type": "address"
+                }
+            ],
+            "name": "ProtocolFeeControllerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "protocolFeeController",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_ProtocolFeeControllerUpdated"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_ProtocolFeeUpdated.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_ProtocolFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint24",
+                    "name": "protocolFee",
+                    "type": "uint24"
+                }
+            ],
+            "name": "ProtocolFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "protocolFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_ProtocolFeeUpdated"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Swap.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Swap.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "PoolId",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int128",
+                    "name": "amount0",
+                    "type": "int128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int128",
+                    "name": "amount1",
+                    "type": "int128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint160",
+                    "name": "sqrtPriceX96",
+                    "type": "uint160"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "liquidity",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int24",
+                    "name": "tick",
+                    "type": "int24"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint24",
+                    "name": "fee",
+                    "type": "uint24"
+                }
+            ],
+            "name": "Swap",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sqrtPriceX96",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidity",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tick",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Swap"
+    }
+}

--- a/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Transfer.json
+++ b/parse/table_definitions_optimism/uniswap/uniswapv4/PoolManager_event_Transfer.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswapv4",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolManager_event_Transfer"
+    }
+}


### PR DESCRIPTION
## What?
This PR ingests the parsed output for the Uniswap V4 Pool Manager contract on Optimism, Base and Arbitrum.
- Optimism PoolManager Contract Address: `0x9a13f98cb987694c9f086b1f5eb990eea8264ec3`
- Base PoolManager Contract Address: `0x498581ff718922c3f8e6a244956af099b2652b2b`
- Arbitrum PoolManager Contract Address: `0x360e68faccca8ca495c1b759fd9eee466db9fb32`

## How? 
ie: I used Nansen's [abi-parser](https://nansen-contract-parser-prod.web.app/) 


